### PR TITLE
Add toy quantum prehash demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Argon2 Quantum
 
+This project demonstrates a toy "quantum" pre-hash followed by a classic
+memory-hard KDF. The quantum step is simulated and **not** real security.
+
+## Usage
+
+```bash
+python qsargon2.py mypassword --salt deadbeefcafebabe
+```
+
+The script prints a Base64 digest derived from the password, salt and a fixed
+pepper. The `qsargon2.qstretch` function is deterministic and unit tested.
+```
+

--- a/qsargon2.py
+++ b/qsargon2.py
@@ -1,0 +1,71 @@
+"""Quantum stretch and Argon2 wrapper."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from typing import Optional
+
+PEPPER = b"fixedPepper32B01234567890123"  # 24 bytes to keep example short
+
+
+def _reverse_bits(value: int, bit_width: int) -> int:
+    """Reverse bits of ``value`` given ``bit_width``."""
+    return int(f"{value:0{bit_width}b}"[::-1], 2)
+
+
+def qstretch(password: str, salt: bytes, pepper: bytes = PEPPER) -> bytes:
+    """Return 256-bit stretched digest.
+
+    The function is deterministic and reversible in spirit but implemented
+    classically for this demo.
+    """
+    data = password.encode() + salt + pepper
+    digest = hashlib.sha512(data).digest()  # 64 bytes
+    result = bytearray()
+    for i in range(0, len(digest), 8):
+        chunk = digest[i : i + 8]
+        val = int.from_bytes(chunk, "big")
+        rev = _reverse_bits(val, 64)
+        result.extend(rev.to_bytes(8, "big"))
+    return bytes(result[:32])
+
+
+def hash_password(
+    password: str,
+    salt: Optional[bytes] = None,
+    pepper: bytes = PEPPER,
+) -> bytes:
+    """Hash ``password`` using qstretch + scrypt.
+
+    Args:
+        password: Raw password string.
+        salt: Optional salt. Random if ``None``.
+        pepper: Server-side pepper bytes.
+
+    Returns:
+        32-byte digest.
+    """
+    if salt is None:
+        salt = secrets.token_bytes(16)
+    pre = qstretch(password, salt, pepper)
+    digest = hashlib.scrypt(pre, salt=salt, n=2**14, r=8, p=1, dklen=32)
+    return digest
+
+
+def main() -> None:
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Demo Argon2 Quantum wrapper")
+    parser.add_argument("password", help="Password to hash")
+    parser.add_argument("--salt", help="Hex salt", default=None)
+    args = parser.parse_args()
+    salt = bytes.fromhex(args.salt) if args.salt else secrets.token_bytes(16)
+    digest = hash_password(args.password, salt)
+    print(base64.b64encode(digest).decode())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qsargon2.py
+++ b/tests/test_qsargon2.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import qsargon2
+
+
+def test_qstretch_deterministic():
+    salt = b"\x00" * 16
+    digest1 = qsargon2.qstretch("password", salt)
+    digest2 = qsargon2.qstretch("password", salt)
+    assert digest1 == digest2
+
+
+def test_hash_password_length():
+    salt = b"\x01" * 16
+    digest = qsargon2.hash_password("pw", salt)
+    assert len(digest) == 32


### PR DESCRIPTION
## Summary
- implement a minimal `qstretch` prehash and a `hash_password` wrapper using `scrypt`
- provide CLI usage example in README
- add unit tests demonstrating determinism and digest length

## Testing
- `ruff check qsargon2.py tests/test_qsargon2.py`
- `mypy qsargon2.py tests/test_qsargon2.py`
- `pytest -q`
- `bandit` *(fails: command not found)*
- `osv-scanner` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d4bc358c8333b2da3fdae41d5d91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a password hashing utility combining a quantum-inspired stretching function with a classic memory-hard key derivation.
  * Added a command-line interface to generate password hashes with optional salt input.
* **Documentation**
  * Expanded the README with a project overview, usage instructions, and example commands.
* **Tests**
  * Added tests to verify deterministic output and correct digest length for the hashing functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->