### PR TITLE
Fix CI Ruff Missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 qiskit
 argon2-cffi
+ruff


### PR DESCRIPTION
## Summary
- install Ruff in the dependency list

## Testing
- `pytest -q`
- `ruff check .`
- `mypy qs_kdf qsargon2.py tests` *(fails: Missing imports)*
- `bandit -r qs_kdf qsargon2.py`

------
https://chatgpt.com/codex/tasks/task_e_6862e8bcd7548333b18267ffb3b94ddc