### PR TITLE
Add password verification features

### DIFF
--- a/qs_kdf/__init__.py
+++ b/qs_kdf/__init__.py
@@ -1,7 +1,14 @@
 """Quantum stretch KDF package."""
 
-from .core import lambda_handler, hash_password, LocalBackend
+from .core import lambda_handler, hash_password, verify_password, LocalBackend
 from .cli import main as cli
 from .test_backend import TestBackend
 
-__all__ = ["lambda_handler", "cli", "TestBackend", "hash_password", "LocalBackend"]
+__all__ = [
+    "lambda_handler",
+    "cli",
+    "TestBackend",
+    "hash_password",
+    "verify_password",
+    "LocalBackend",
+]

--- a/qs_kdf/core.py
+++ b/qs_kdf/core.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import os
+import secrets
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -83,6 +84,18 @@ def hash_password(
         type=Type.ID,
     )
     return digest
+
+
+def verify_password(
+    password: str,
+    salt: bytes,
+    digest: bytes,
+    backend: Backend | None = None,
+    pepper: bytes | None = None,
+) -> bool:
+    """Return ``True`` if password and salt match ``digest``."""
+    candidate = hash_password(password, salt, backend=backend, pepper=pepper)
+    return secrets.compare_digest(candidate, digest)
 
 
 class RedisCache:

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -46,3 +46,26 @@ def test_timing_attack():
     qs_kdf.hash_password("bad", salt, backend=backend)
     bad = time.perf_counter() - start_bad
     assert abs(good - bad) <= 0.01
+
+
+def test_verify_password():
+    salt = b"\x03" * 16
+    backend = qs_kdf.TestBackend()
+    digest = qs_kdf.hash_password("pw", salt, backend=backend)
+    assert qs_kdf.verify_password("pw", salt, digest, backend=backend)
+    assert not qs_kdf.verify_password("bad", salt, digest, backend=backend)
+
+
+def test_cli_verify():
+    backend = qs_kdf.LocalBackend()
+    salt = b"\x04" * 16
+    digest = qs_kdf.hash_password("pw", salt, backend=backend)
+    out = _run_cli([
+        "verify",
+        "pw",
+        "--salt",
+        "04" * 16,
+        "--digest",
+        digest.hex(),
+    ])
+    assert out == "OK"


### PR DESCRIPTION
## Summary
- support verifying passwords via `verify_password`
- expand CLI with new `verify` command
- test verification logic and CLI

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645f48c57883339c63ebf6eb88a19a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a password verification function to the application.
  * Introduced a new "verify" command to the command-line interface for checking password validity.

* **Tests**
  * Added tests for password verification functionality and CLI verification command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->