### PR TITLE
Expand documentation with getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,25 @@
 This project demonstrates a toy "quantum" pre-hash followed by a classic
 memory-hard KDF. The quantum step is simulated and **not** real security.
 
-## Usage
+## Getting Started
+
+Install dependencies and run the CLI to hash a password with a hex salt:
 
 ```bash
-python qsargon2.py mypassword --salt deadbeefcafebabe
+pip install -r requirements.txt
+python -m qs_kdf hash mypassword --salt deadbeefcafebabe
 ```
 
-The script prints a Base64 digest derived from the password, salt and a fixed
-pepper. The `qsargon2.qstretch` function is deterministic and unit tested.
+The output digest can later be verified with the `verify` subcommand:
+
+```bash
+python -m qs_kdf verify mypassword --salt deadbeefcafebabe --digest <hex>
 ```
+
+For an overview of the approach and deployment tips see the documents in
+[`docs/`](docs/).
 
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for
 details.
-

--- a/docs/KDF.md
+++ b/docs/KDF.md
@@ -2,17 +2,24 @@
 
 ## Threat Model
 
-| Actor         | Capability                      | Mitigation                   |
-|---------------|---------------------------------|------------------------------|
-| Offline brute | Tries to guess passwords        | Quantum stretch + Argon2     |
-| Insider       | Reads DB and cache              | KMS protected pepper         |
-| Network       | Snoops traffic                  | TLS enforced by API Gateway  |
+| Actor         | Capability               | Mitigation                     |
+|---------------|-------------------------|--------------------------------|
+| Offline brute | Tries to guess passwords| Quantum stretch + Argon2       |
+| Insider       | Reads DB and cache      | KMS protected pepper           |
+| Network       | Snoops traffic          | TLS enforced by API Gateway    |
+
+The quantum byte is fetched from AWS Braket in production or generated locally
+during development. This makes brute-force attempts expensive because each
+password guess must reproduce the extra step.
 
 ## Flow Diagram
 
 ```
 client -> API Gateway -> Lambda qs_kdf -> Redis/KMS -> Braket -> Argon2
 ```
+
+Redis caches the quantum byte for a short period to reduce latency. The Lambda
+function can operate without the cache but will incur extra calls to Braket.
 
 ## API Example
 
@@ -22,6 +29,6 @@ curl -X POST /auth/qs-login -d '{"password":"pw","salt":"01"}'
 
 ## Rollback
 
-1. Disable Braket call in Lambda.
-2. Keep Argon2 verification with stored digest.
-3. Re-enable classical path only.
+1. Disable the Braket call in Lambda.
+2. Keep Argon2 verification with the stored digest.
+3. Re-enable the classical path only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+This guide walks through hashing and verifying a password with the simulated
+quantum stretch. A Python 3.10+ environment is required.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Hash a Password
+
+```bash
+python -m qs_kdf hash "hunter2" --salt 0011223344556677
+```
+
+Pass `--cloud` to route the request through the Lambda handler. In this demo it
+returns a fixed value but shows how the API would be used in production.
+
+## Verify a Password
+
+```bash
+python -m qs_kdf verify "hunter2" --salt 0011223344556677 --digest <hex>
+```
+
+`verify` exits with the digest result printed to stdout (`OK` or `NOPE`).
+
+## Deploying the Lambda
+
+The `infra` directory contains an AWS CDK stack that provisions the Lambda,
+KMS key and Redis cache. Deploy with:
+
+```bash
+cd infra
+cdk deploy
+```
+
+The placeholder quantum step calls AWS Braket. You must provide appropriate
+credentials and network access for the deployment to succeed.

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -1,7 +1,10 @@
 # Quantum Stretch KDF Overview
 
-Quantum layer increases current offline cracking cost ~1 000×; not a full
-post-quantum guarantee once fault-tolerant QPUs exist.
+The quantum step adds a single byte from a quantum-inspired service to the
+Argon2 salt. This increases the offline cracking cost by forcing attackers to
+replicate the service call for each guess. It is not a post‑quantum scheme—once
+large fault-tolerant QPUs exist the advantage disappears.
 
-Migration path uses a two-hash approach so the quantum call can be removed later
-without forcing user password resets.
+A two-hash migration stores both the classical digest and the quantum-extended
+version. The extra step can later be removed without requiring all users to
+reset their passwords.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -3,7 +3,8 @@
 ## Cache Keys
 
 Redis keys derive from `sha256(salt)` with a 120s TTL. Cached quantum bytes
-avoid repeated Braket calls.
+avoid repeated Braket calls. The cache window slightly reduces entropy but keeps
+latency acceptable for interactive logins.
 
 ## Failure Modes
 


### PR DESCRIPTION
## Summary
- explain how to install and run the CLI in README
- clarify quantum stretch approach in docs
- give deployment tips and cache notes in KDF docs
- detail cache caveats in runbook
- add a new `Getting Started` walkthrough

## Testing
- `ruff check .`
- `bandit -c .bandit.yml -r qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867eed75e9883339887710f9caf99f8