### PR TITLE
Add Dockerfile and usage docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+ENTRYPOINT ["./qsargon2"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ python -m qs_kdf verify mypassword --salt deadbeefcafebabe --digest <hex>
 For an overview of the approach and deployment tips see the documents in
 [`docs/`](docs/).
 
+## Container Usage
+
+Build the Docker image and run the CLI via the bundled entry point:
+
+```bash
+docker build -t qsargon2 .
+docker run --rm qsargon2 hash mypassword --salt deadbeefcafebabe
+```
+
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for


### PR DESCRIPTION
## Summary
- add Dockerfile with qsargon2 entrypoint
- document container build and run instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867f9243a80833383d5aa911b129074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the application in a Docker container.

* **Documentation**
  * Updated the README with instructions for building and running the application using Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->