### PR TITLE
Update docs with deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Argon2 Quantum
 
-This project demonstrates a toy "quantum" pre-hash followed by a classic
-memory-hard KDF. The quantum step is simulated and **not** real security.
+This project demonstrates a simulated "quantum" pre-hash followed by a classic
+memory-hard KDF. The quantum step is emulated and **not** real security.
 
 ## Getting Started
+
+### Prerequisites
+
+- An AWS account with permissions to create Lambda, KMS and Braket resources via CDK or Terraform.
+- Configured IAM credentials using the [AWS CLI](https://docs.aws.amazon.com/cli/).
 
 Install dependencies and run the CLI to hash a password with a hex salt:
 
@@ -18,7 +23,23 @@ The output digest can later be verified with the `verify` subcommand:
 python -m qs_kdf verify mypassword --salt deadbeefcafebabe --digest <hex>
 ```
 
-For an overview of the approach and deployment tips see the documents in
+Running without `--cloud` keeps all computation local using the built-in
+simulator backend.
+
+The stack in [`infra/qs_kdf_stack.py`](infra/qs_kdf_stack.py) can be deployed
+with a single command:
+
+```bash
+cd infra && cdk deploy
+```
+
+or using Terraform:
+
+```bash
+terraform -chdir=terraform apply
+```
+
+For an overview of the approach and more deployment tips see the documents in
 [`docs/`](docs/).
 
 ## License

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,6 +3,12 @@
 This guide walks through hashing and verifying a password with the simulated
 quantum stretch. A Python 3.10+ environment is required.
 
+## Prerequisites
+
+- An AWS account with permissions to deploy resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/) installed and configured with
+  IAM credentials.
+
 ## Installation
 
 ```bash
@@ -15,8 +21,10 @@ pip install -r requirements.txt
 python -m qs_kdf hash "hunter2" --salt 0011223344556677
 ```
 
-Pass `--cloud` to route the request through the Lambda handler. In this demo it
-returns a fixed value but shows how the API would be used in production.
+By default the command uses a local simulator backend and requires no AWS
+connectivity. Pass `--cloud` to route the request through the Lambda handler.
+In this demo it returns a fixed value but shows how the API would be used in
+production.
 
 ## Verify a Password
 
@@ -28,13 +36,20 @@ python -m qs_kdf verify "hunter2" --salt 0011223344556677 --digest <hex>
 
 ## Deploying the Lambda
 
-The `infra` directory contains an AWS CDK stack that provisions the Lambda,
-KMS key and Redis cache. Deploy with:
+The stack defined in [`infra/qs_kdf_stack.py`](../infra/qs_kdf_stack.py)
+provisions the Lambda, KMS key and Redis cache. Deploy with:
 
 ```bash
-cd infra
-cdk deploy
+cd infra && cdk deploy
+```
+
+Alternatively run:
+
+```bash
+terraform -chdir=terraform apply
 ```
 
 The placeholder quantum step calls AWS Braket. You must provide appropriate
-credentials and network access for the deployment to succeed.
+credentials and network access for the deployment to succeed. See the
+[Braket documentation](https://docs.aws.amazon.com/braket/latest/developerguide/)
+for further details.


### PR DESCRIPTION
## Summary
- remove toy language from README and docs
- add AWS prerequisites and offline simulator usage
- show one-liner for deploying via CDK or Terraform
- link out to Braket docs for more info

## Testing
- `ruff check .`
- `pytest -q`
- `bandit -r qs_kdf`


------
https://chatgpt.com/codex/tasks/task_e_6867f91054a0833387c5a780d074f998