### PR TITLE
Implement real AWS KMS byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Argon2 Quantum
 
-This project demonstrates a simulated "quantum" pre-hash followed by a classic
-memory-hard KDF. The quantum step is emulated and **not** real security.
+This project demonstrates a quantum inspired pre-hash using a random byte
+retrieved from AWS KMS followed by a classic memory-hard KDF. The quantum step
+is implemented via the `GenerateRandom` API to show a true service call.
 
 ## Getting Started
 

--- a/docs/KDF.md
+++ b/docs/KDF.md
@@ -8,18 +8,18 @@
 | Insider       | Reads DB and cache      | KMS protected pepper           |
 | Network       | Snoops traffic          | TLS enforced by API Gateway    |
 
-The quantum byte is fetched from AWS Braket in production or generated locally
+The quantum byte is fetched from AWS KMS in production or generated locally
 during development. This makes brute-force attempts expensive because each
 password guess must reproduce the extra step.
 
 ## Flow Diagram
 
 ```
-client -> API Gateway -> Lambda qs_kdf -> Redis/KMS -> Braket -> Argon2
+client -> API Gateway -> Lambda qs_kdf -> Redis/KMS -> KMS -> Argon2
 ```
 
 Redis caches the quantum byte for a short period to reduce latency. The Lambda
-function can operate without the cache but will incur extra calls to Braket.
+function can operate without the cache but will incur extra calls to KMS.
 
 ## API Example
 
@@ -29,6 +29,6 @@ curl -X POST /auth/qs-login -d '{"password":"pw","salt":"01"}'
 
 ## Rollback
 
-1. Disable the Braket call in Lambda.
+1. Disable the KMS call in Lambda.
 2. Keep Argon2 verification with the stored digest.
 3. Re-enable the classical path only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ Alternatively run:
 terraform -chdir=terraform apply
 ```
 
-The placeholder quantum step calls AWS Braket. You must provide appropriate
-credentials and network access for the deployment to succeed. See the
-[Braket documentation](https://docs.aws.amazon.com/braket/latest/developerguide/)
+The random byte is fetched from AWS KMS using the `GenerateRandom` API. Ensure
+your credentials permit this call. See the
+[KMS documentation](https://docs.aws.amazon.com/kms/latest/APIReference/)
 for further details.

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -1,9 +1,9 @@
 # Quantum Stretch KDF Overview
 
-The quantum step adds a single byte from a quantum-inspired service to the
-Argon2 salt. This increases the offline cracking cost by forcing attackers to
-replicate the service call for each guess. It is not a post‑quantum scheme—once
-large fault-tolerant QPUs exist the advantage disappears.
+The quantum step adds a single byte from AWS KMS to the Argon2 salt. This
+increases the offline cracking cost by forcing attackers to replicate the
+service call for each guess. It is not a post‑quantum scheme—once large
+fault-tolerant QPUs exist the advantage disappears.
 
 A two-hash migration stores both the classical digest and the quantum-extended
 version. The extra step can later be removed without requiring all users to

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -3,13 +3,13 @@
 ## Cache Keys
 
 Redis keys derive from `sha256(salt)` with a 120s TTL. Cached quantum bytes
-avoid repeated Braket calls. The cache window slightly reduces entropy but keeps
+avoid repeated KMS calls. The cache window slightly reduces entropy but keeps
 latency acceptable for interactive logins.
 
 ## Failure Modes
 
-* **Braket Timeout**: Step Function enforces a 200 ms deadline and falls back to
-a deterministic slice when exceeded.
+* **KMS Timeout**: Step Function enforces a 200 ms deadline and falls back to
+  a deterministic slice when exceeded.
 * **KMS Failure**: Lambda returns an error; monitoring via CloudWatch.
 * **Redis Unavailable**: Lambda proceeds without cache and stores result when
 possible.

--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -1,7 +1,13 @@
 """Quantum stretch KDF package."""
 
-from .core import lambda_handler, hash_password, verify_password, LocalBackend
 from .cli import main as cli
+from .core import (
+    KmsBackend,
+    LocalBackend,
+    hash_password,
+    lambda_handler,
+    verify_password,
+)
 from .test_backend import TestBackend
 
 __all__ = [
@@ -11,4 +17,5 @@ __all__ = [
     "hash_password",
     "verify_password",
     "LocalBackend",
+    "KmsBackend",
 ]

--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from .core import LocalBackend, hash_password, verify_password, lambda_handler
+from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -20,7 +20,9 @@ def main(argv: list[str] | None = None) -> int:
     salt = bytes.fromhex(args.salt)
     if args.cmd == "hash":
         if args.cloud:
-            response = lambda_handler({"password": args.password, "salt": args.salt}, None)
+            response = lambda_handler(
+                {"password": args.password, "salt": args.salt}, None
+            )
             digest_hex = response["digest"]
         else:
             backend = LocalBackend()

--- a/src/qs_kdf/test_backend.py
+++ b/src/qs_kdf/test_backend.py
@@ -6,7 +6,7 @@ __test__ = False
 
 class TestBackend:
     def __init__(self, seed: int = 42):
-        self.random = random.Random(seed)
+        self.random = random.Random(seed)  # nosec B311 - deterministic helper
 
     def run(self, seed_bytes: bytes) -> bytes:
         self.random.seed(int.from_bytes(seed_bytes[:4], "big"))


### PR DESCRIPTION
## Summary
- use AWS KMS `GenerateRandom` for the quantum salt byte
- document KMS usage
- add `KmsBackend` and wire up lambda
- test the new backend

## Testing
- `ruff check --fix src tests`
- `black src tests`
- `isort src tests`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686809e8ea8c83338ab544835038428a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a backend that fetches a random byte from AWS KMS for the quantum-inspired pre-hash step.
  * Added a test to verify the new AWS KMS backend functionality.

* **Documentation**
  * Updated all documentation to clarify that AWS KMS is now used for quantum byte generation, replacing previous references to AWS Braket.
  * Improved deployment, operational, and overview documentation to reflect the new KMS integration.

* **Chores**
  * Added security annotation comments to clarify intentional use of deterministic randomness in tests.
  * Refactored import statements and formatting for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->