### PR TITLE
Add ELI5 section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This project demonstrates a quantum inspired pre-hash using a random byte
 retrieved from AWS KMS followed by a classic memory-hard KDF. The quantum step
 is implemented via the `GenerateRandom` API to show a true service call.
 
+## ELI5
+
+Imagine you want to lock your cookie jar with a secret code. This project adds
+a tiny piece of random "sprinkle" from the cloud before scrambling the code
+with Argon2. That extra sprinkle makes it much harder for someone else to guess
+your password, even with big computers.
+
 ## Getting Started
 
 ### Prerequisites

--- a/infra/qs_kdf_stack.py
+++ b/infra/qs_kdf_stack.py
@@ -1,10 +1,10 @@
 from aws_cdk import Duration, Stack
 from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_elasticache as ec
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_kms as kms
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_logs as logs
-from aws_cdk import aws_elasticache as ec
 from aws_cdk import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as tasks
 from constructs import Construct

--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -1,13 +1,8 @@
 """Quantum stretch KDF package."""
 
 from .cli import main as cli
-from .core import (
-    KmsBackend,
-    LocalBackend,
-    hash_password,
-    lambda_handler,
-    verify_password,
-)
+from .core import (KmsBackend, LocalBackend, hash_password, lambda_handler,
+                   verify_password)
 from .test_backend import TestBackend
 
 __all__ = [


### PR DESCRIPTION
## Summary
- describe the project in plain language for beginners
- run auto-formatters to keep imports sorted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868168627408333afec4255d5a146fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an "ELI5" section to the README to provide a simple analogy explaining the project's concept.

* **Style**
  * Reformatted import statements for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->