### PR TITLE
Add docstring for lambda handler

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import secrets
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 _warmed_up = False
 
@@ -63,7 +63,7 @@ class LocalBackend:
 class KmsBackend:
     """Backend fetching one byte from AWS KMS."""
 
-    kms_client: object | None = None
+    kms_client: Any | None = None
 
     def __post_init__(self) -> None:
         if self.kms_client is None:
@@ -130,6 +130,15 @@ class RedisCache:
 
 
 def lambda_handler(event: dict, _ctx) -> dict:
+    """Handle Argon2id hashing request via AWS Lambda.
+
+    Args:
+        event: Invocation payload containing "salt" and "password".
+        _ctx: Lambda context object (unused).
+
+    Returns:
+        dict: Response with hex digest under "digest".
+    """
     import boto3  # type: ignore
     import redis  # type: ignore
 


### PR DESCRIPTION
## Summary
- document lambda_handler arguments and return
- annotate kms_client type for mypy

## Testing
- `ruff check --fix src tests`
- `ruff format src tests`
- `isort src tests`
- `black src tests`
- `prettier -w README.md`
- `mypy src`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868298d77e8833380a1f414a77cfc5b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed docstring to the lambda handler function, clarifying its usage and expected input/output.

* **Refactor**
  * Updated type annotations for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->