### PR TITLE
Add gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Caches and logs
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+
+# Distribution / packaging
+build/
+dist/
+.eggs/
+*.egg-info/
+
+# Virtual environments
+venv/
+.env/
+.venv/
+ENV/
+
+# Test coverage
+coverage.*
+.coverage
+
+# IDE settings
+.idea/
+.vscode/

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import secrets
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, Any
 
 _warmed_up = False
 
@@ -63,7 +63,7 @@ class LocalBackend:
 class KmsBackend:
     """Backend fetching one byte from AWS KMS."""
 
-    kms_client: object | None = None
+    kms_client: Any | None = None
 
     def __post_init__(self) -> None:
         if self.kms_client is None:


### PR DESCRIPTION
## Summary
- create `.gitignore` to hide bytecode, caches and virtualenvs
- fix `KmsBackend` typing so mypy passes

## Testing
- `pytest -q`
- `mypy src tests`
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_686829a48398833398321a12e74e66c6