### PR TITLE
Adjust Bandit hook path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 1.7.8
     hooks:
       - id: bandit
-        args: ["-c", ".bandit.yml", "-r", "qs_kdf"]
+        args: ["-c", ".bandit.yml", "-r", "src/qs_kdf"]
   - repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
## Summary
- configure Bandit to scan `src/qs_kdf`

## Testing
- `pytest -q`
- `pre-commit run --files src/qs_kdf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686829a717748333b0856bcca524ede8