### PR TITLE
Update pepper comment

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import secrets
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 _warmed_up = False
 
@@ -63,7 +63,7 @@ class LocalBackend:
 class KmsBackend:
     """Backend fetching one byte from AWS KMS."""
 
-    kms_client: object | None = None
+    kms_client: Any | None = None
 
     def __post_init__(self) -> None:
         if self.kms_client is None:

--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -7,7 +7,7 @@ import hashlib
 import secrets
 from typing import Optional
 
-PEPPER = b"fixedPepper32B01234567890123"  # 24 bytes to keep example short
+PEPPER = b"fixedPepper32B01234567890123"  # 28 bytes to keep example short
 
 
 def _reverse_bits(value: int, bit_width: int) -> int:


### PR DESCRIPTION
## Summary
- correct pepper comment to match 28 byte length
- annotate KMS backend client to satisfy mypy

## Testing
- `black src/qs_kdf/core.py src/qsargon2.py`
- `isort src/qs_kdf/core.py src/qsargon2.py`
- `ruff check src/qs_kdf/core.py src/qsargon2.py`
- `ruff format src/qs_kdf/core.py src/qsargon2.py`
- `prettier -w README.md`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686829bc38d48333826dd209de5bf01b