### PR TITLE
Add missing docstrings

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -4,6 +4,14 @@ from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Execute the command-line interface.
+
+    Args:
+        argv: Optional list of arguments.
+
+    Returns:
+        Process exit code.
+    """
     parser = argparse.ArgumentParser(prog="qs_kdf")
     sub = parser.add_subparsers(dest="cmd", required=True)
     h = sub.add_parser("hash")

--- a/src/qs_kdf/test_backend.py
+++ b/src/qs_kdf/test_backend.py
@@ -5,9 +5,13 @@ __test__ = False
 
 
 class TestBackend:
+    """Deterministic backend for tests."""
+
     def __init__(self, seed: int = 42):
+        """Initialize random generator with ``seed``."""
         self.random = random.Random(seed)  # nosec B311 - deterministic helper
 
     def run(self, seed_bytes: bytes) -> bytes:
+        """Return pseudo-random byte derived from ``seed_bytes``."""
         self.random.seed(int.from_bytes(seed_bytes[:4], "big"))
         return self.random.randbytes(1)


### PR DESCRIPTION
## Summary
- document CLI interface and lambda handler
- add docs for Redis cache helper and test backend

## Testing
- `ruff check src/qs_kdf/core.py src/qs_kdf/cli.py src/qs_kdf/test_backend.py`
- `ruff format src/qs_kdf/core.py src/qs_kdf/cli.py src/qs_kdf/test_backend.py`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `mypy src/qs_kdf`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686829c617c883338a147b6c43697b0e