### PR TITLE
Update pepper length to 32 bytes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,6 +26,9 @@ connectivity. Pass `--cloud` to route the request through the Lambda handler.
 In this demo it returns a fixed value but shows how the API would be used in
 production.
 
+The repository ships with a static 32-byte pepper used for these examples.
+Replace it with your own secret when deploying.
+
 ## Verify a Password
 
 ```bash

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -88,7 +88,7 @@ def hash_password(
     if backend is None:
         backend = LocalBackend()
     if pepper is None:
-        pepper = b"fixedPepper32B01234567890123"
+        pepper = b"fixedPepper32B012345678901234567"
     pre = hashlib.sha512(password.encode() + salt + pepper).digest()
     quantum = backend.run(pre)
     new_salt = salt + quantum

--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -7,7 +7,7 @@ import hashlib
 import secrets
 from typing import Optional
 
-PEPPER = b"fixedPepper32B01234567890123"  # 24 bytes to keep example short
+PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo
 
 
 def _reverse_bits(value: int, bit_width: int) -> int:


### PR DESCRIPTION
## Summary
- set the demo pepper to 32 bytes
- note the pepper length in the getting started guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683406019483338aafa558ab72e6e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying that the example uses a static 32-byte pepper and advising users to replace it with their own secret for production use.

* **Refactor**
  * Updated the default pepper value to a 32-byte constant in password hashing components to enhance consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->