### PR TITLE
Add explicit warning about PQ security

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@ This project demonstrates a quantum inspired pre-hash using a random byte
 retrieved from AWS KMS followed by a classic memory-hard KDF. The quantum step
 is implemented via the `GenerateRandom` API to show a true service call.
 
+> **Security Notice**
+> 
+> The approach only raises the cost of classical offline attacks. It does
+> **not** provide post-quantum security.
+
 ## ELI5
 
 Imagine you want to lock your cookie jar with a secret code. This project adds
 a tiny piece of random "sprinkle" from the cloud before scrambling the code
-with Argon2. That extra sprinkle makes it much harder for someone else to guess
-your password, even with big computers.
+with Argon2. The sprinkle slows down classical attackers but offers no
+resistance once quantum computers arrive.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- warn prominently that the KDF is not post‑quantum secure
- soften ELI5 example so it doesn't imply quantum resistance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868342c8b60833397d660c7820b23f6