### PR TITLE
Use AWS Braket for quantum byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Argon2 Quantum
 
 This project demonstrates a quantum inspired pre-hash using a random byte
-retrieved from AWS KMS followed by a classic memory-hard KDF. The quantum step
-is implemented via the `GenerateRandom` API to show a true service call.
+retrieved from AWS Braket followed by a classic memory-hard KDF. The quantum
+step executes a simple circuit on the managed simulator.
 
 ## ELI5
 

--- a/docs/KDF.md
+++ b/docs/KDF.md
@@ -8,18 +8,18 @@
 | Insider       | Reads DB and cache      | KMS protected pepper           |
 | Network       | Snoops traffic          | TLS enforced by API Gateway    |
 
-The quantum byte is fetched from AWS KMS in production or generated locally
+The quantum byte is fetched from AWS Braket in production or generated locally
 during development. This makes brute-force attempts expensive because each
 password guess must reproduce the extra step.
 
 ## Flow Diagram
 
 ```
-client -> API Gateway -> Lambda qs_kdf -> Redis/KMS -> KMS -> Argon2
+client -> API Gateway -> Lambda qs_kdf -> Redis/Braket -> Braket -> Argon2
 ```
 
 Redis caches the quantum byte for a short period to reduce latency. The Lambda
-function can operate without the cache but will incur extra calls to KMS.
+function can operate without the cache but will incur extra calls to Braket.
 
 ## API Example
 
@@ -29,6 +29,6 @@ curl -X POST /auth/qs-login -d '{"password":"pw","salt":"01"}'
 
 ## Rollback
 
-1. Disable the KMS call in Lambda.
+1. Disable the Braket call in Lambda.
 2. Keep Argon2 verification with the stored digest.
 3. Re-enable the classical path only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ Alternatively run:
 terraform -chdir=terraform apply
 ```
 
-The random byte is fetched from AWS KMS using the `GenerateRandom` API. Ensure
-your credentials permit this call. See the
-[KMS documentation](https://docs.aws.amazon.com/kms/latest/APIReference/)
+The random byte is fetched from AWS Braket by running a tiny circuit. Ensure
+your credentials permit Braket execution. See the
+[Braket documentation](https://docs.aws.amazon.com/braket/)
 for further details.

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -1,6 +1,6 @@
 # Quantum Stretch KDF Overview
 
-The quantum step adds a single byte from AWS KMS to the Argon2 salt. This
+The quantum step adds a single byte from AWS Braket to the Argon2 salt. This
 increases the offline cracking cost by forcing attackers to replicate the
 service call for each guess. It is not a post‑quantum scheme—once large
 fault-tolerant QPUs exist the advantage disappears.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -3,14 +3,14 @@
 ## Cache Keys
 
 Redis keys derive from `sha256(salt)` with a 120s TTL. Cached quantum bytes
-avoid repeated KMS calls. The cache window slightly reduces entropy but keeps
+avoid repeated Braket calls. The cache window slightly reduces entropy but keeps
 latency acceptable for interactive logins.
 
 ## Failure Modes
 
-* **KMS Timeout**: Step Function enforces a 200 ms deadline and falls back to
+* **Braket Timeout**: Step Function enforces a 200 ms deadline and falls back to
   a deterministic slice when exceeded.
-* **KMS Failure**: Lambda returns an error; monitoring via CloudWatch.
+* **Braket Failure**: Lambda returns an error; monitoring via CloudWatch.
 * **Redis Unavailable**: Lambda proceeds without cache and stores result when
 possible.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "argon2-cffi",
     "boto3",
     "redis",
+    "amazon-braket-sdk",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ruff
 boto3
 redis
 pytest-cov
+amazon-braket-sdk

--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -2,7 +2,7 @@
 
 from .cli import main as cli
 from .core import (
-    KmsBackend,
+    BraketBackend,
     LocalBackend,
     hash_password,
     lambda_handler,
@@ -17,5 +17,5 @@ __all__ = [
     "hash_password",
     "verify_password",
     "LocalBackend",
-    "KmsBackend",
+    "BraketBackend",
 ]


### PR DESCRIPTION
## Summary
- fetch random bytes from AWS Braket instead of KMS
- adjust lambda handler and backend
- update docs to mention Braket
- extend tests for Braket backend

## Testing
- `ruff check --fix .`
- `black src tests`
- `isort .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686834dc1f108333b383e9e727bfe721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched the quantum randomness source from AWS KMS to AWS Braket quantum simulator for the key derivation process.

* **Documentation**
  * Updated all documentation to reference AWS Braket instead of AWS KMS for quantum byte generation, including setup instructions, threat models, and operational details.

* **Chores**
  * Added the `amazon-braket-sdk` dependency to project requirements.

* **Refactor**
  * Replaced KMS backend logic and tests with Braket backend implementations and corresponding test updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->