### PR TITLE
Add configurable byte count for Braket backend

### DIFF
--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -111,3 +111,7 @@ def test_braket_backend(monkeypatch):
     backend = qs_kdf.BraketBackend(device=FakeDevice("01000010"))
     result = backend.run(b"seed")
     assert result == b"\x42"
+
+    backend2 = qs_kdf.BraketBackend(device=FakeDevice("01000010"), num_bytes=2)
+    result2 = backend2.run(b"seed")
+    assert result2 == b"\x42\x42"


### PR DESCRIPTION
## Summary
- support multi-byte randomness in `BraketBackend`
- test configurable byte output

## Testing
- `ruff format src/qs_kdf/core.py tests/test_qs_kdf.py`
- `ruff check src/qs_kdf/core.py tests/test_qs_kdf.py --fix`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683a4447508333b77a2143fc279af4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced random byte generation to support fetching multiple bytes at once, both locally and via AWS Braket.

* **Tests**
  * Expanded test coverage to verify correct output when requesting multiple random bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->