### PR TITLE
Centralize pepper constant

### DIFF
--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -1,0 +1,1 @@
+PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -5,6 +5,8 @@ import secrets
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
+from .constants import PEPPER
+
 _warmed_up = False
 
 
@@ -99,7 +101,7 @@ def hash_password(
     if backend is None:
         backend = LocalBackend()
     if pepper is None:
-        pepper = b"fixedPepper32B012345678901234567"
+        pepper = PEPPER
     pre = hashlib.sha512(password.encode() + salt + pepper).digest()
     quantum = backend.run(pre)
     new_salt = salt + quantum

--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -7,7 +7,7 @@ import hashlib
 import secrets
 from typing import Optional
 
-PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo
+from qs_kdf.constants import PEPPER
 
 
 def qstretch(password: str, salt: bytes, pepper: bytes = PEPPER) -> bytes:


### PR DESCRIPTION
## Summary
- centralize pepper value in `qs_kdf.constants`
- reference new constant from `core.py` and `qsargon2.py`

## Testing
- `ruff check src/qs_kdf/core.py src/qsargon2.py src/qs_kdf/constants.py`
- `mypy src`
- `bandit -r src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68683b8d243883339a201b7185bd5a59