### PR TITLE
Fix long scrypt line in qsargon2

### DIFF
--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -19,7 +19,14 @@ except Exception:  # pragma: no cover - optional fallback
         hash_len: int,
         type: int,
     ) -> bytes:
-        return hashlib.scrypt(password, salt=salt, n=2**14, r=8, p=parallelism, dklen=hash_len)
+        return hashlib.scrypt(
+            password,
+            salt=salt,
+            n=2**14,
+            r=8,
+            p=parallelism,
+            dklen=hash_len,
+        )
 import secrets
 from typing import Optional
 


### PR DESCRIPTION
## Summary
- break hashlib.scrypt call across lines to comply with 88-char limit

## Testing
- `ruff check src/qsargon2.py`

------
https://chatgpt.com/codex/tasks/task_e_6868577a5bcc8333be2c782b4451f2f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting for better readability; no changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->