### PR TITLE
Enforce Argon2 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
+          pip install argon2-cffi
           pip install ruff
           pip install -r infra/requirements.txt
       - name: Ruff

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ resistance once quantum computers arrive.
 - An AWS account with permissions to create Lambda, KMS and Braket resources via CDK or Terraform.
 - Configured IAM credentials using the [AWS CLI](https://docs.aws.amazon.com/cli/).
 
-Install dependencies and run the CLI to hash a password with a hex salt:
+Install dependencies and run the CLI to hash a password with a hex salt.
+`argon2-cffi` is required and will be installed automatically:
 
 ```bash
 pip install .

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,7 @@ quantum stretch. A Python 3.10+ environment is required.
 
 ```bash
 pip install .
+# argon2-cffi is installed as a required dependency
 ```
 
 ## Hash a Password

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -29,24 +29,10 @@ def _warm_up() -> None:
 
 try:
     from argon2.low_level import Type, hash_secret_raw  # type: ignore
-except Exception:  # pragma: no cover - optional
-
-    class Type:  # type: ignore[no-redef]
-        ID = 2
-
-    def hash_secret_raw(
-        password: bytes,
-        salt: bytes,
-        time_cost: int,
-        memory_cost: int,
-        parallelism: int,
-        hash_len: int,
-        type: int,
-        *,
-        secret: bytes | None = None,
-    ) -> bytes:
-        data = password if secret is None else password + secret
-        return hashlib.pbkdf2_hmac("sha256", data, salt, 1, dklen=hash_len)
+except Exception as exc:  # pragma: no cover - enforce dependency
+    raise ImportError(
+        "argon2-cffi must be installed; run 'pip install argon2-cffi'"
+    ) from exc
 
 
 class Backend(Protocol):

--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -6,20 +6,10 @@ import base64
 import hashlib
 try:
     from argon2.low_level import Type, hash_secret_raw
-except Exception:  # pragma: no cover - optional fallback
-    class Type:  # type: ignore[no-redef]
-        ID = 2
-
-    def hash_secret_raw(
-        password: bytes,
-        salt: bytes,
-        time_cost: int,
-        memory_cost: int,
-        parallelism: int,
-        hash_len: int,
-        type: int,
-    ) -> bytes:
-        return hashlib.scrypt(password, salt=salt, n=2**14, r=8, p=parallelism, dklen=hash_len)
+except Exception as exc:  # pragma: no cover - enforce dependency
+    raise ImportError(
+        "argon2-cffi must be installed; run 'pip install argon2-cffi'"
+    ) from exc
 import secrets
 from typing import Optional
 


### PR DESCRIPTION
## Summary
- raise ImportError if argon2-cffi missing
- mention argon2-cffi requirement in README and docs
- install argon2-cffi in CI workflow

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'argon2')*

------
https://chatgpt.com/codex/tasks/task_e_686857af8a408333b8794848e9c4980e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions in the README and getting started guide to explicitly state that the `argon2-cffi` package is required and will be installed automatically.

* **Bug Fixes**
  * Enforced the requirement for the `argon2-cffi` package by removing fallback implementations and providing clear error messages if the package is missing.

* **Chores**
  * Updated continuous integration workflow to install the `argon2-cffi` package during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->