### PR TITLE
Store quantum byte in DynamoDB

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -6,6 +6,10 @@ Redis keys derive from `sha256(salt)` with a 120s TTL. Cached quantum bytes
 avoid repeated Braket calls. The cache window slightly reduces entropy but keeps
 latency acceptable for interactive logins.
 
+Each finalized digest is also stored in DynamoDB with the quantum byte used to
+derive it. Items expire after one hour via the table's TTL attribute. During
+verification the byte is fetched to reproduce the same salt extension.
+
 ## Failure Modes
 
 * **Braket Timeout**: Step Function enforces a 200 ms deadline and falls back to


### PR DESCRIPTION
## Summary
- persist quantum byte in DynamoDB
- fetch stored quantum byte during password verification
- outline persistence in the runbook
- test DynamoDB integration

## Testing
- `ruff check src tests`
- `pytest -q`
- `mypy src tests --ignore-missing-imports`
- `bandit -r src -q`


------
https://chatgpt.com/codex/tasks/task_e_686857706c788333b402133557c8183d