### PR TITLE
Update pepper handling

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,9 @@ connectivity. Pass `--cloud` to route the request through the Lambda handler.
 In this demo it returns a fixed value but shows how the API would be used in
 production.
 
-The repository ships with a static 32-byte pepper used for these examples.
-Replace it with your own secret when deploying.
+Set a base64 encoded pepper via the ``PEPPER`` environment variable or use
+``PEPPER_CIPHERTEXT`` and ``KMS_KEY_ID`` for a KMS encrypted value. The demo
+constant has been removed.
 
 ## Verify a Password
 

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -1,1 +1,3 @@
-PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo
+"""Project constants."""
+
+# Intentionally left blank; use environment variables for secrets.

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -93,6 +93,7 @@ class FakeRedisModule:
 
 @pytest.fixture()
 def _env(monkeypatch):
+    monkeypatch.delenv("PEPPER", raising=False)
     monkeypatch.setenv("KMS_KEY_ID", "my-key")
     monkeypatch.setenv("PEPPER_CIPHERTEXT", base64.b64encode(b"cipher").decode())
     monkeypatch.setenv("REDIS_HOST", "r")

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -4,8 +4,15 @@ import io
 import time
 import sys
 import types
+import base64
+import os
 
 import qs_kdf
+
+os.environ.setdefault(
+    "PEPPER",
+    base64.b64encode(b"fixedPepper32B012345678901234567").decode(),
+)
 
 cli_module = importlib.import_module("qs_kdf.cli")
 

--- a/tests/test_qsargon2.py
+++ b/tests/test_qsargon2.py
@@ -1,9 +1,15 @@
 import os
 import sys
+import base64
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import qsargon2
+
+os.environ.setdefault(
+    "PEPPER",
+    base64.b64encode(b"fixedPepper32B012345678901234567").decode(),
+)
 
 
 def test_qstretch_deterministic():


### PR DESCRIPTION
## Summary
- load pepper from environment variables
- refactor lambda handler to use new loader
- update getting-started docs with new instructions
- adjust tests for new pepper handling

## Testing
- `ruff check --fix src/qs_kdf/constants.py src/qs_kdf/core.py src/qsargon2.py tests/test_qsargon2.py tests/test_qs_kdf.py tests/test_lambda_handler.py`
- `ruff format src/qs_kdf/constants.py src/qs_kdf/core.py src/qsargon2.py tests/test_qsargon2.py tests/test_qs_kdf.py tests/test_lambda_handler.py`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `mypy --ignore-missing-imports src/qs_kdf src/qsargon2.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868575893c08333b5bcdf9dab6eeb26