### PR TITLE
Require argon2 and update tests

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -29,24 +29,10 @@ def _warm_up() -> None:
 
 try:
     from argon2.low_level import Type, hash_secret_raw  # type: ignore
-except Exception:  # pragma: no cover - optional
-
-    class Type:  # type: ignore[no-redef]
-        ID = 2
-
-    def hash_secret_raw(
-        password: bytes,
-        salt: bytes,
-        time_cost: int,
-        memory_cost: int,
-        parallelism: int,
-        hash_len: int,
-        type: int,
-        *,
-        secret: bytes | None = None,
-    ) -> bytes:
-        data = password if secret is None else password + secret
-        return hashlib.pbkdf2_hmac("sha256", data, salt, 1, dklen=hash_len)
+except ImportError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "argon2-cffi is required for qs_kdf.core; install it first"
+    ) from exc
 
 
 class Backend(Protocol):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import hashlib
+import sys
+import types
+
+
+def _fake_hash_secret_raw(
+    pw, salt, time_cost, memory_cost, parallelism, hash_len, type, *, secret=None
+):
+    return hashlib.scrypt(
+        pw if secret is None else pw + secret,
+        salt=salt,
+        n=2**14,
+        r=8,
+        p=parallelism,
+        dklen=hash_len,
+    )
+
+
+stub = types.SimpleNamespace(
+    Type=types.SimpleNamespace(ID=2),
+    hash_secret_raw=_fake_hash_secret_raw,
+)
+
+sys.modules.setdefault("argon2.low_level", stub)

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -1,44 +1,70 @@
 import contextlib
+import hashlib
 import importlib
 import io
-import time
 import sys
+import time
 import types
 
-import qs_kdf
 
-cli_module = importlib.import_module("qs_kdf.cli")
+def _fake_hash_secret_raw(
+    pw, salt, time_cost, memory_cost, parallelism, hash_len, type, *, secret=None
+):
+    return hashlib.scrypt(
+        pw if secret is None else pw + secret,
+        salt=salt,
+        n=2**14,
+        r=8,
+        p=parallelism,
+        dklen=hash_len,
+    )
 
 
-def test_hash_password_length():
+def _load_modules(monkeypatch):
+    stub = types.SimpleNamespace(
+        Type=types.SimpleNamespace(ID=2),
+        hash_secret_raw=_fake_hash_secret_raw,
+    )
+    monkeypatch.setitem(sys.modules, "argon2.low_level", stub)
+    qs_kdf = importlib.import_module("qs_kdf")
+    cli_module = importlib.import_module("qs_kdf.cli")
+    return qs_kdf, cli_module
+
+
+def test_hash_password_length(monkeypatch):
+    qs_kdf, _ = _load_modules(monkeypatch)
     salt = b"\x01" * 16
     backend = qs_kdf.TestBackend()
     digest = qs_kdf.hash_password("pw", salt, backend=backend)
     assert len(digest) == 32
 
 
-def _run_cli(argv: list[str]) -> str:
+def _run_cli(cli_module, argv: list[str]) -> str:
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         cli_module.main(argv)
     return buf.getvalue().strip()
 
 
-def test_cli_output_local():
-    out = _run_cli(["hash", "pw", "--salt", "01" * 16])
+def test_cli_output_local(monkeypatch):
+    _, cli_module = _load_modules(monkeypatch)
+    out = _run_cli(cli_module, ["hash", "pw", "--salt", "01" * 16])
     assert out
 
 
 def test_cli_output_cloud(monkeypatch):
+    qs_kdf, cli_module = _load_modules(monkeypatch)
+
     def fake_handler(event: dict, _ctx: object) -> dict:
         return {"digest": "deadbeef"}
 
     monkeypatch.setattr(cli_module, "lambda_handler", fake_handler)
-    out = _run_cli(["hash", "pw", "--salt", "01" * 16, "--cloud"])
+    out = _run_cli(cli_module, ["hash", "pw", "--salt", "01" * 16, "--cloud"])
     assert out == "deadbeef"
 
 
-def test_timing_attack():
+def test_timing_attack(monkeypatch):
+    qs_kdf, _ = _load_modules(monkeypatch)
     salt = b"\x02" * 16
     backend = qs_kdf.TestBackend()
     start_good = time.perf_counter()
@@ -50,7 +76,8 @@ def test_timing_attack():
     assert abs(good - bad) <= 0.05
 
 
-def test_verify_password():
+def test_verify_password(monkeypatch):
+    qs_kdf, _ = _load_modules(monkeypatch)
     salt = b"\x03" * 16
     backend = qs_kdf.TestBackend()
     digest = qs_kdf.hash_password("pw", salt, backend=backend)
@@ -58,11 +85,13 @@ def test_verify_password():
     assert not qs_kdf.verify_password("bad", salt, digest, backend=backend)
 
 
-def test_cli_verify():
+def test_cli_verify(monkeypatch):
+    qs_kdf, cli_module = _load_modules(monkeypatch)
     backend = qs_kdf.LocalBackend()
     salt = b"\x04" * 16
     digest = qs_kdf.hash_password("pw", salt, backend=backend)
     out = _run_cli(
+        cli_module,
         [
             "verify",
             "pw",
@@ -70,12 +99,14 @@ def test_cli_verify():
             "04" * 16,
             "--digest",
             digest.hex(),
-        ]
+        ],
     )
     assert out == "OK"
 
 
 def test_braket_backend(monkeypatch):
+    qs_kdf, _ = _load_modules(monkeypatch)
+
     class FakeCircuit:
         def h(self, *args, **kwargs):
             return self


### PR DESCRIPTION
## Summary
- remove PBKDF2 fallback and insist on argon2-cffi
- provide argon2 stubs for tests via conftest
- adapt tests to load modules after stubbing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868575a562483338271011edcf53878