### PR TITLE
Add qsargon2 entry script test

### DIFF
--- a/tests/test_entry_script.py
+++ b/tests/test_entry_script.py
@@ -1,0 +1,28 @@
+import base64
+import contextlib
+import io
+import runpy
+import sys
+
+import qsargon2
+
+
+def _run_cli(argv: list[str]) -> str:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        old_argv = sys.argv
+        sys.argv = ["qsargon2", *argv]
+        try:
+            runpy.run_module("qsargon2", run_name="__main__")
+        finally:
+            sys.argv = old_argv
+    return buf.getvalue().strip()
+
+
+def test_entry_script_deterministic():
+    salt = b"\x05" * 16
+    salt_hex = salt.hex()
+    out1 = _run_cli(["pw", "--salt", salt_hex])
+    out2 = _run_cli(["pw", "--salt", salt_hex])
+    expected = base64.b64encode(qsargon2.hash_password("pw", salt)).decode()
+    assert out1 == out2 == expected


### PR DESCRIPTION
## Summary
- test entry script with runpy
- ensure deterministic digest with same password and salt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689c9c6ad8833392f609c535e6cbe3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify that running the command-line interface with fixed arguments produces consistent and correct hashing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->