### PR TITLE
Add tests for CLI verify failure and lambda invalid salt

### DIFF
--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -161,6 +161,17 @@ def test_lambda_handler_cache_hit(monkeypatch, _env):
     assert not redis_client.set_calls
 
 
+def test_lambda_handler_invalid_salt(monkeypatch, _env):
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("00000000")
+    redis_client = FakeRedisClient()
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = {"password": "pw", "salt": "zz"}
+    with pytest.raises(ValueError):
+        lambda_handler(event, None)
+
+
 @pytest.mark.parametrize("var", ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"])
 def test_lambda_handler_missing_env(monkeypatch, var, _env):
     redis_client = FakeRedisClient()

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -1,8 +1,8 @@
 import contextlib
 import importlib
 import io
-import time
 import sys
+import time
 import types
 
 import qs_kdf
@@ -73,6 +73,23 @@ def test_cli_verify():
         ]
     )
     assert out == "OK"
+
+
+def test_cli_verify_nope():
+    backend = qs_kdf.LocalBackend()
+    salt = b"\x05" * 16
+    qs_kdf.hash_password("pw", salt, backend=backend)
+    out = _run_cli(
+        [
+            "verify",
+            "pw",
+            "--salt",
+            "05" * 16,
+            "--digest",
+            "00" * 32,
+        ]
+    )
+    assert out == "NOPE"
 
 
 def test_braket_backend(monkeypatch):


### PR DESCRIPTION
## Summary
- check CLI 'verify' outputs NOPE on mismatch
- validate lambda handler fails on invalid hex salt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689d01c194833382ae6b8e5b6d1436