### PR TITLE
Add docstrings and improve documentation

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -1,9 +1,20 @@
+"""Command-line interface for hashing and verifying passwords."""
+
 import argparse
 
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and hash or verify a password.
+
+    Args:
+        argv: Optional list of command-line arguments.
+
+    Returns:
+        int: ``0`` on success.
+    """
+
     parser = argparse.ArgumentParser(prog="qs_kdf")
     sub = parser.add_subparsers(dest="cmd", required=True)
     h = sub.add_parser("hash")

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -1,1 +1,3 @@
+"""Constant values used across the quantum stretch KDF."""
+
 PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo

--- a/src/qs_kdf/test_backend.py
+++ b/src/qs_kdf/test_backend.py
@@ -5,9 +5,26 @@ __test__ = False
 
 
 class TestBackend:
+    """Deterministic backend for testing."""
+
     def __init__(self, seed: int = 42):
+        """Initialize RNG with ``seed``.
+
+        Args:
+            seed: Seed for deterministic randomness.
+        """
+
         self.random = random.Random(seed)  # nosec B311 - deterministic helper
 
     def run(self, seed_bytes: bytes) -> bytes:
+        """Return one deterministic byte derived from ``seed_bytes``.
+
+        Args:
+            seed_bytes: Seed material for the PRNG.
+
+        Returns:
+            bytes: One random byte.
+        """
+
         self.random.seed(int.from_bytes(seed_bytes[:4], "big"))
         return self.random.randbytes(1)


### PR DESCRIPTION
## Summary
- document CLI and constants modules
- add imperative docstrings for public functions
- format with ruff and black

## Testing
- `ruff check --fix src/qs_kdf tests`
- `black src/qs_kdf tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689c905a7483339fc206de9f80e378