### PR TITLE
Handle invalid hex args in CLI

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -17,7 +17,12 @@ def main(argv: list[str] | None = None) -> int:
     v.add_argument("--digest", required=True)
 
     args = parser.parse_args(argv)
-    salt = bytes.fromhex(args.salt)
+    try:
+        salt = bytes.fromhex(args.salt)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"invalid hex value for --salt: {args.salt}"
+        ) from exc
     if args.cmd == "hash":
         if args.cloud:
             response = lambda_handler(
@@ -29,7 +34,12 @@ def main(argv: list[str] | None = None) -> int:
             digest_hex = hash_password(args.password, salt, backend=backend).hex()
         print(digest_hex)
     else:
-        digest = bytes.fromhex(args.digest)
+        try:
+            digest = bytes.fromhex(args.digest)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"invalid hex value for --digest: {args.digest}"
+            ) from exc
         backend = LocalBackend()
         ok = verify_password(args.password, salt, digest, backend=backend)
         print("OK" if ok else "NOPE")

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -1,9 +1,12 @@
+import argparse
 import contextlib
 import importlib
 import io
-import time
 import sys
+import time
 import types
+
+import pytest
 
 import qs_kdf
 
@@ -115,3 +118,13 @@ def test_braket_backend(monkeypatch):
     backend2 = qs_kdf.BraketBackend(device=FakeDevice("01000010"), num_bytes=2)
     result2 = backend2.run(b"seed")
     assert result2 == b"\x42\x42"
+
+
+def test_cli_invalid_salt():
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli_module.main(["hash", "pw", "--salt", "zz"])
+
+
+def test_cli_invalid_digest():
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli_module.main(["verify", "pw", "--salt", "01" * 16, "--digest", "zz"])


### PR DESCRIPTION
## Summary
- raise `ArgumentTypeError` when `--salt` or `--digest` are not hex
- test CLI failure scenarios

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689cc1c63c8333a0d65de365dbd315