### PR TITLE
Add codecov support and badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         python: ["3.10", "3.11"]
@@ -28,6 +30,12 @@ jobs:
         run: |
           pip install pytest pytest-cov
           pytest --cov=src --cov-report=xml --cov-fail-under=70
+      - name: Upload coverage
+        if: env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          token: ${{ env.CODECOV_TOKEN }}
       - name: CDK Synth
         working-directory: infra
         run: cdk synth

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Argon2 Quantum
 
+[![CI](https://github.com/KristopherKubicki/argon2_quantum/actions/workflows/ci.yml/badge.svg)](https://github.com/KristopherKubicki/argon2_quantum/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/KristopherKubicki/argon2_quantum/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/argon2_quantum)
+
 This project demonstrates a quantum inspired pre-hash using ten random bytes
 retrieved from AWS Braket followed by a classic memory-hard KDF. The quantum
 step executes a simple circuit on the managed simulator.


### PR DESCRIPTION
## Summary
- upload coverage to Codecov when token is present
- display CI and coverage badges in the README

## Testing
- `ruff check .`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868abe5aed08333947126ab23c19955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to upload code coverage reports automatically.
* **Documentation**
  * Added badges to the README for CI status and code coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->