### PR TITLE
Ensure argon2-cffi installed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r infra/requirements.txt
           pip install .
-          pip install argon2-cffi
           pip install ruff
           pip install bandit
-          pip install -r infra/requirements.txt
       - name: Ruff
         run: ruff check .
       - name: Bandit


### PR DESCRIPTION
## Summary
- install dependencies from requirements.txt in CI
- ensure argon2-cffi available before running tests

## Testing
- `ruff check .`
- `black . --check`
- `isort --profile black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ad7483ec833384ab3306cf80a504