### PR TITLE
Refactor hash_password to use qstretch

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -126,7 +126,7 @@ def hash_password(
         backend = LocalBackend()
     if pepper is None:
         pepper = PEPPER
-    pre = hashlib.sha512(password.encode() + salt + pepper).digest()
+    pre = qstretch(password, salt, pepper=pepper)
     quantum = backend.run(pre)
     new_salt = salt + quantum
     digest = hash_secret_raw(


### PR DESCRIPTION
## Summary
- refactor `hash_password` to call `qstretch`
- ensure output unchanged using legacy algorithm in tests

## Testing
- `ruff check src/qs_kdf/core.py tests/test_qs_kdf.py tests/test_qsargon2.py`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ad417bfc833387d79e42dd861dd8