### PR TITLE
Add fail-fast for Braket backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,5 @@
 - Ensure `pytest` passes.
 - The `BraketBackend` in `src/qs_kdf/core.py` must fail with `RuntimeError`
   if AWS Braket is unavailable. Do not use placeholder randomness.
+  Initialization should handle missing SDK or credentials gracefully and
+  only raise when ``run`` is called.

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -80,12 +80,12 @@ class BraketBackend:
         if self.device is None:
             try:
                 from braket.aws import AwsDevice  # type: ignore
-            except Exception:  # pragma: no cover - optional
-                self.device = None
-            else:
+
                 self.device = AwsDevice(
                     "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
                 )
+            except Exception:  # pragma: no cover - optional
+                self.device = None
 
     def run(self, _seed: bytes) -> bytes:
         """Return ``num_bytes`` random bytes from Braket."""

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -137,7 +137,17 @@ def test_braket_backend(monkeypatch):
     assert result2 == b"\x42\x42"
 
 
-def test_braket_backend_unavailable():
+def test_braket_backend_unavailable(monkeypatch):
+    class FailingDevice:
+        def __init__(self, *args, **kwargs) -> None:
+            raise Exception("unavailable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "braket.aws",
+        types.SimpleNamespace(AwsDevice=FailingDevice),
+    )
+
     backend = qs_kdf.BraketBackend(device=None)
     with pytest.raises(RuntimeError):
         backend.run(b"seed")


### PR DESCRIPTION
## Summary
- raise an error instead of using a fallback if AWS Braket is unavailable
- test failure path
- document rule in AGENTS file

## Testing
- `ruff format src/qs_kdf/core.py tests/test_qs_kdf.py`
- `ruff check src/qs_kdf/core.py tests/test_qs_kdf.py --fix`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868add87fd08333ac4be8d3a3890a93