### PR TITLE
Remove static PEPPER constant

### DIFF
--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -1,14 +1,8 @@
 """Quantum stretch KDF package."""
 
 from .cli import main as cli
-from .core import (
-    BraketBackend,
-    LocalBackend,
-    hash_password,
-    lambda_handler,
-    qstretch,
-    verify_password,
-)
+from .core import (BraketBackend, LocalBackend, hash_password, lambda_handler,
+                   qstretch, verify_password)
 from .test_backend import TestBackend
 
 __all__ = [

--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for hashing and verifying passwords."""
 
 import argparse
+import os
 
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
@@ -21,11 +22,19 @@ def main(argv: list[str] | None = None) -> int:
     h.add_argument("password")
     h.add_argument("--salt", required=True)
     h.add_argument("--cloud", action="store_true")
+    h.add_argument(
+        "--pepper",
+        help="hex encoded pepper or from QS_KDF_PEPPER env variable",
+    )
 
     v = sub.add_parser("verify")
     v.add_argument("password")
     v.add_argument("--salt", required=True)
     v.add_argument("--digest", required=True)
+    v.add_argument(
+        "--pepper",
+        help="hex encoded pepper or from QS_KDF_PEPPER env variable",
+    )
 
     args = parser.parse_args(argv)
     try:
@@ -34,6 +43,20 @@ def main(argv: list[str] | None = None) -> int:
         raise argparse.ArgumentTypeError(
             f"invalid hex value for --salt: {args.salt}"
         ) from exc
+    pepper_hex = args.pepper or os.environ.get("QS_KDF_PEPPER")
+    needs_pepper = args.cmd == "verify" or (args.cmd == "hash" and not args.cloud)
+    pepper: bytes = b""
+    if needs_pepper:
+        if pepper_hex is None:
+            raise argparse.ArgumentTypeError(
+                "pepper required via --pepper or QS_KDF_PEPPER"
+            )
+        try:
+            pepper = bytes.fromhex(pepper_hex)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"invalid hex value for --pepper: {pepper_hex}"
+            ) from exc
     if args.cmd == "hash":
         if args.cloud:
             response = lambda_handler(
@@ -42,7 +65,9 @@ def main(argv: list[str] | None = None) -> int:
             digest_hex = response["digest"]
         else:
             backend = LocalBackend()
-            digest_hex = hash_password(args.password, salt, backend=backend).hex()
+            digest_hex = hash_password(
+                args.password, salt, backend=backend, pepper=pepper
+            ).hex()
         print(digest_hex)
     else:
         try:
@@ -52,7 +77,9 @@ def main(argv: list[str] | None = None) -> int:
                 f"invalid hex value for --digest: {args.digest}"
             ) from exc
         backend = LocalBackend()
-        ok = verify_password(args.password, salt, digest, backend=backend)
+        ok = verify_password(
+            args.password, salt, digest, backend=backend, pepper=pepper
+        )
         print("OK" if ok else "NOPE")
     return 0
 

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -1,3 +1,1 @@
 """Constant values used across the quantum stretch KDF."""
-
-PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo

--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -2,6 +2,7 @@
 
 import argparse
 import base64
+import os
 import secrets
 
 from qs_kdf.core import hash_password, qstretch
@@ -15,9 +16,24 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="qsargon2")
     parser.add_argument("password")
     parser.add_argument("--salt")
+    parser.add_argument(
+        "--pepper",
+        help="hex encoded pepper or from QS_KDF_PEPPER env variable",
+    )
     args = parser.parse_args(argv)
     salt = bytes.fromhex(args.salt) if args.salt else secrets.token_bytes(16)
-    digest = hash_password(args.password, salt)
+    pepper_hex = args.pepper or os.environ.get("QS_KDF_PEPPER")
+    if pepper_hex is None:
+        raise argparse.ArgumentTypeError(
+            "pepper required via --pepper or QS_KDF_PEPPER"
+        )
+    try:
+        pepper = bytes.fromhex(pepper_hex)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"invalid hex value for --pepper: {pepper_hex}"
+        ) from exc
+    digest = hash_password(args.password, salt, pepper=pepper)
     print(base64.b64encode(digest).decode())
     return 0
 

--- a/tests/test_entry_script.py
+++ b/tests/test_entry_script.py
@@ -6,6 +6,8 @@ import sys
 
 import qsargon2
 
+PEPPER = b"p" * 32
+
 
 def _run_cli(argv: list[str]) -> str:
     buf = io.StringIO()
@@ -22,7 +24,9 @@ def _run_cli(argv: list[str]) -> str:
 def test_entry_script_deterministic():
     salt = b"\x05" * 16
     salt_hex = salt.hex()
-    out1 = _run_cli(["pw", "--salt", salt_hex])
-    out2 = _run_cli(["pw", "--salt", salt_hex])
-    expected = base64.b64encode(qsargon2.hash_password("pw", salt)).decode()
+    out1 = _run_cli(["pw", "--salt", salt_hex, "--pepper", PEPPER.hex()])
+    out2 = _run_cli(["pw", "--salt", salt_hex, "--pepper", PEPPER.hex()])
+    expected = base64.b64encode(
+        qsargon2.hash_password("pw", salt, pepper=PEPPER)
+    ).decode()
     assert out1 == out2 == expected

--- a/tests/test_qsargon2.py
+++ b/tests/test_qsargon2.py
@@ -1,5 +1,7 @@
 import qs_kdf
 
+PEPPER = b"p" * 32
+
 
 def test_qstretch_deterministic():
     salt = b"\x00" * 16
@@ -11,5 +13,5 @@ def test_qstretch_deterministic():
 
 def test_hash_password_length():
     salt = b"\x01" * 16
-    digest = qs_kdf.hash_password("pw", salt)
+    digest = qs_kdf.hash_password("pw", salt, pepper=PEPPER)
     assert len(digest) == 32


### PR DESCRIPTION
## Summary
- drop unused PEPPER constant
- require pepper argument for `hash_password` and `verify_password`
- update CLI tools to load pepper from argument or environment
- adjust tests for the new API

## Testing
- `pytest -q`
- `mypy src`
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_6868ad5505dc8333b7c2289e6d7693c4