### PR TITLE
Optimize BraketBackend task execution

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -95,12 +95,11 @@ class BraketBackend:
         from braket.circuits import Circuit  # type: ignore
 
         circuit = Circuit().h(range(8)).measure(range(8))
+        task = self.device.run(circuit, shots=self.num_bytes)
+        result = task.result()
         result_bytes = bytearray()
-        for _ in range(self.num_bytes):
-            task = self.device.run(circuit, shots=1)
-            result = task.result()
-            bits = next(iter(result.measurement_counts))
-            result_bytes.extend(int(bits, 2).to_bytes(1, "big"))
+        for bits, count in result.measurement_counts.items():
+            result_bytes.extend(int(bits, 2).to_bytes(1, "big") * count)
         return bytes(result_bytes)
 
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -30,27 +30,29 @@ class FakeKMS:
 
 
 class FakeResult:
-    def __init__(self, bits: str) -> None:
-        self.measurement_counts = {bits: 1}
+    def __init__(self, bits: str, shots: int) -> None:
+        self.measurement_counts = {bits: shots}
 
 
 class FakeTask:
-    def __init__(self, bits: str) -> None:
+    def __init__(self, bits: str, shots: int) -> None:
         self._bits = bits
+        self._shots = shots
 
     def result(self):
-        return FakeResult(self._bits)
+        return FakeResult(self._bits, self._shots)
 
 
 class FakeBraketDevice:
     def __init__(self, bits: str) -> None:
         self.bits = bits
         self.run_calls = 0
+        self.shots: list[int] = []
 
     def run(self, circuit, shots: int):
         self.run_calls += 1
-        assert shots == 1
-        return FakeTask(self.bits)
+        self.shots.append(shots)
+        return FakeTask(self.bits, shots)
 
 
 class FakeCircuit:


### PR DESCRIPTION
## Summary
- fetch all Braket bytes in one task
- adapt tests to new batching behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ad57ec9083339f40d1d49e09045c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved efficiency of quantum measurement result collection, reducing the number of device runs and optimizing performance.

* **Tests**
  * Enhanced test simulations to support variable measurement repetitions, improving test coverage for different quantum backend scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->