### PR TITLE
Update deployment docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,17 +40,10 @@ python -m qs_kdf verify "hunter2" --salt 0011223344556677 --digest <hex>
 
 ## Deploying the Lambda
 
-The stack defined in [`infra/qs_kdf_stack.py`](../infra/qs_kdf_stack.py)
-provisions the Lambda, KMS key and Redis cache. Deploy with:
+The infrastructure is defined using the AWS CDK. Deploy with:
 
 ```bash
 cd infra && cdk deploy
-```
-
-Alternatively run:
-
-```bash
-terraform -chdir=terraform apply
 ```
 
 The random bytes are fetched from AWS Braket by running a tiny circuit. Ensure


### PR DESCRIPTION
## Summary
- clarify deployment docs to use AWS CDK only

## Testing
- `pre-commit run --files docs/getting-started.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b63ae1888333a288f81735034bc1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to reference only AWS CDK, removing specific file references and alternative Terraform commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->