### PR TITLE
Implement single-shot run for Braket

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -6,6 +6,10 @@ Redis keys derive from `sha256(salt)` with a 120s TTL. Cached quantum bytes
 avoid repeated Braket calls. The cache window slightly reduces entropy but keeps
 latency acceptable for interactive logins.
 
+Recent versions request all ten quantum shots in a single `device.run` call.
+This reduces network latency and simplifies error handling compared to the
+previous per-shot loop.
+
 ## Failure Modes
 
 * **Braket Timeout**: Step Function enforces a 200 ms deadline and falls back to

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -257,13 +257,12 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     device = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
     circuit = Circuit().h(range(8)).measure(range(8))
 
-    def _producer():
+    def _producer() -> bytes:
+        task = device.run(circuit, shots=10)
+        result = task.result()
         result_bytes = bytearray()
-        for _ in range(10):
-            task = device.run(circuit, shots=1)
-            result = task.result()
-            bits = next(iter(result.measurement_counts))
-            result_bytes.extend(int(bits, 2).to_bytes(1, "big"))
+        for bits, count in result.measurement_counts.items():
+            result_bytes.extend(int(bits, 2).to_bytes(1, "big") * count)
         return bytes(result_bytes)
 
     quantum_bytes = cache.get_or_set(key, 120, _producer)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -143,7 +143,8 @@ def test_lambda_handler_cache_miss(monkeypatch, _env):
 
     assert result["digest"] == _expected_digest("pw", event["salt"], pepper, quantum)
     assert kms.decrypt_called == 1
-    assert device.run_calls == 10
+    assert device.run_calls == 1
+    assert device.shots == [10]
     assert redis_client.set_calls
 
 


### PR DESCRIPTION
## Summary
- use one device.run call when fetching Braket bytes
- adjust lambda tests for the new behaviour
- mention new approach in runbook

## Testing
- `pre-commit run --files src/qs_kdf/core.py tests/test_lambda_handler.py docs/runbook.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b59305f88333a4d7be9c051041f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to note that quantum operations now request all ten shots in a single call, improving efficiency.
* **Bug Fixes**
  * Optimized quantum measurement collection to reduce the number of device runs from 10 to 1, enhancing performance.
* **Tests**
  * Updated tests to reflect the new single-call approach for quantum device runs and to verify correct shot parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->