### PR TITLE
Add env var checks for CLI cloud mode

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,22 @@ production.
 The repository ships with a static 32-byte pepper used for these examples.
 Replace it with your own secret when deploying.
 
+### Cloud mode
+
+Running with `--cloud` invokes the deployed Lambda. Set the following
+environment variables so the CLI can locate the key, pepper and cache:
+
+```bash
+export KMS_KEY_ID=<kms-key-id>
+export PEPPER_CIPHERTEXT=<base64-ciphertext>
+export REDIS_HOST=<redis-endpoint>
+# Optional when not using the default port
+export REDIS_PORT=6379
+```
+
+`cdk deploy` prints these values after provisioning. Export them before
+executing the command.
+
 ## Verify a Password
 
 ```bash

--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for hashing and verifying passwords."""
 
 import argparse
+import os
 
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
@@ -36,6 +37,12 @@ def main(argv: list[str] | None = None) -> int:
         ) from exc
     if args.cmd == "hash":
         if args.cloud:
+            required = ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"]
+            missing = [v for v in required if v not in os.environ]
+            if missing:
+                parser.error(
+                    "--cloud requires environment variables: " + ", ".join(missing)
+                )
             response = lambda_handler(
                 {"password": args.password, "salt": args.salt}, None
             )


### PR DESCRIPTION
## Summary
- validate required env vars before running lambda handler
- document cloud config via environment variables
- test CLI when env vars are missing

## Testing
- `pre-commit run --files src/qs_kdf/cli.py docs/getting-started.md tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b5a7c6c083339be9730f6d14681e