### PR TITLE
Update CI to rely on pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,9 @@ jobs:
           pip install -r requirements.txt
           pip install -r infra/requirements.txt
           pip install .
-          pip install ruff
-          pip install bandit
-      - name: Ruff
-        run: ruff check .
-      - name: Bandit
-        run: bandit -c .bandit.yml -r src/qs_kdf
+          pip install pre-commit
+      - name: Pre-commit
+        run: pre-commit run --show-diff-on-failure --color always --all-files
       - name: Tests
         run: |
           pip install pytest pytest-cov


### PR DESCRIPTION
## Summary
- run Ruff and Bandit via pre-commit
- remove redundant ruff/bandit installs

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b5ee3b488333b18db6c889531dd7