### PR TITLE
Add development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ cdk synth
 
 Deploy the stack using `cdk deploy` when you're ready.
 
+## Development
+
+Use Python 3.10 or newer. Install the hooks once:
+
+```bash
+pre-commit install
+```
+
+Run the hooks on changed files and execute tests before committing:
+
+```bash
+pre-commit run --files <files>
+pytest
+```
+
+Tools like `mypy` or `bandit` can optionally be run for extra checks.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for


### PR DESCRIPTION
## Summary
- add a Development section in the README to cover common tasks

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686927df36a88333a7beb73b748363e3