### PR TITLE
Add py-modules for qsargon2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ qs_kdf = "qs_kdf.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+py-modules = ["qsargon2"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- ensure packaging includes the legacy `qsargon2` module

## Testing
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `pip install --no-build-isolation --no-deps .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869282e87988333b933ea0de5944e76