### PR TITLE
Update runbook to remove fallback note

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -12,8 +12,8 @@ previous per-shot loop.
 
 ## Failure Modes
 
-* **Braket Timeout**: Step Function enforces a 200 ms deadline and falls back to
-  a deterministic slice when exceeded.
+* **Braket Timeout**: Step Function enforces a 200 ms deadline. Invocations
+  exceeding this limit return an error.
 * **Braket Failure**: Lambda returns an error; monitoring via CloudWatch.
 * **Redis Unavailable**: Lambda proceeds without cache and stores result when
 possible.


### PR DESCRIPTION
## Summary
- update Braket timeout description to remove fallback note

## Testing
- `pytest`
- `pre-commit run --files docs/runbook.md src/qs_kdf/core.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68692840c728833381f81391807f18e5