### PR TITLE
Add Python 3.12 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
-        python: ["3.10", "3.11"]
+        python: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python


### PR DESCRIPTION
## Summary
- run CI on Python 3.12 in addition to 3.10 and 3.11

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pytest -q` *(fails: test_timing_attack assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_686927e5a1848333a815f4af9c52921b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing to include Python 3.12 in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->