### PR TITLE
Add num_bytes validation to BraketBackend

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -101,6 +101,9 @@ class BraketBackend:
             :meth:`run` will raise :class:`RuntimeError`.
         """
 
+        if not isinstance(self.num_bytes, int) or self.num_bytes <= 0:
+            raise ValueError("num_bytes must be a positive integer")
+
         if self.device is None:
             try:
                 from braket.aws import AwsDevice  # type: ignore

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -269,3 +269,9 @@ def test_cli_cloud_missing_env(monkeypatch, missing):
     monkeypatch.delenv(missing)
     with pytest.raises(SystemExit):
         cli_module.main(["hash", "pw", "--salt", "01" * 16, "--cloud"])
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, "x"])
+def test_braket_backend_invalid_num_bytes(value):
+    with pytest.raises(ValueError):
+        qs_kdf.BraketBackend(device=object(), num_bytes=value)


### PR DESCRIPTION
## Summary
- ensure `BraketBackend` validates `num_bytes` is a positive integer
- exercise validation in the test suite

## Testing
- `pre-commit run --files src/qs_kdf/core.py tests/test_qs_kdf.py` *(fails: command not found)*
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692846652883338a44dbf45ce15908