### PR TITLE
Add Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python


### PR DESCRIPTION
## Summary
- extend the GitHub Actions matrix to run tests with Python 3.13

## Testing
- `pytest -q`
- ❌ `pre-commit run --files .github/workflows/ci.yml` *(failed: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68692c6ccc64833380290a5808f5b594