### PR TITLE
Clarify Braket hardware default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 [![CI](https://github.com/KristopherKubicki/argon2_quantum/actions/workflows/ci.yml/badge.svg)](https://github.com/KristopherKubicki/argon2_quantum/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/KristopherKubicki/argon2_quantum/graph/badge.svg?token=JuPPmkMFxR)](https://codecov.io/gh/KristopherKubicki/argon2_quantum)
 
-This project demonstrates a quantum inspired pre-hash using ten random bytes
-retrieved from AWS Braket followed by a classic memory-hard KDF. The quantum
-step executes a simple circuit on the managed simulator.
+This project demonstrates a quantum inspired pre-hash using ten random bytes.
+The bytes come from running a tiny qubit circuit via AWS Braket. By default the
+circuit executes on real quantum hardware, though the managed simulator is also
+available. The output then seeds a classic memory-hard KDF.
 
 > **Security Notice**
 > 

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -44,6 +44,8 @@ except Exception as exc:  # pragma: no cover - enforce dependency
         "argon2-cffi must be installed; run 'pip install argon2-cffi'"
     ) from exc
 
+_warm_up()
+
 
 class Backend(Protocol):
     def run(self, seed: bytes) -> bytes:
@@ -116,7 +118,7 @@ class BraketBackend:
 
             try:
                 self.device = AwsDevice(
-                    "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+                    "arn:aws:braket:::device/qpu/ionq/ionQdevice"
                 )
             except NoCredentialsError as exc:  # pragma: no cover - optional
                 logging.getLogger(__name__).error("AWS credentials missing: %s", exc)
@@ -322,7 +324,7 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     seed = bytes.fromhex(salt_hex)
     key = hashlib.sha256(seed).hexdigest()
 
-    device = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
+    device = AwsDevice("arn:aws:braket:::device/qpu/ionq/ionQdevice")
     backend = BraketBackend(device=device)
 
     def _producer() -> bytes:


### PR DESCRIPTION
## Summary
- default Braket backend now uses a real IonQ QPU
- call warm-up during module import to stabilize runtimes
- update README to mention hardware default

## Testing
- `pre-commit run --files README.md src/qs_kdf/core.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692c3f743083338ee970f5887f0fb6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify the source of quantum randomness and the execution environment, specifying use of real quantum hardware by default and improved workflow description.

* **Bug Fixes**
  * Ensured Argon2 memory is preloaded immediately at module load time for improved reliability.

* **Refactor**
  * Switched the default quantum backend from a simulator to a real quantum processing unit for randomness generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->