### PR TITLE
Adjust Lambda packaging path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,17 @@ python -m qs_kdf verify "hunter2" --salt 0011223344556677 --digest <hex>
 
 `verify` exits with the digest result printed to stdout (`OK` or `NOPE`).
 
+## Building the Lambda Artifact
+
+Deployments expect a zipped package under `build/lambda.zip`. Create it with:
+
+```bash
+./scripts/package_lambda.sh
+```
+
+The script installs runtime requirements into `build/lambda`, copies the
+source code and zips the directory for the CDK stack.
+
 ## Deploying the Lambda
 
 The infrastructure is defined using the AWS CDK. Deploy with:

--- a/infra/qs_kdf_stack.py
+++ b/infra/qs_kdf_stack.py
@@ -24,7 +24,7 @@ class QsKdfStack(Stack):
             self,
             "Handler",
             runtime=lambda_.Runtime.PYTHON_3_11,
-            code=lambda_.Code.from_asset("../"),
+            code=lambda_.Code.from_asset("../build/lambda"),
             handler="qs_kdf.lambda_handler",
             role=lambda_role,
             timeout=Duration.seconds(10),

--- a/scripts/package_lambda.sh
+++ b/scripts/package_lambda.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+OUT="$ROOT/build/lambda"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+pip install --quiet --target "$OUT" -r "$ROOT/requirements.txt"
+cp -r "$ROOT"/src/* "$OUT"/
+
+cd "$OUT" && zip -r ../lambda.zip .


### PR DESCRIPTION
## Summary
- package Lambda code into `build/lambda`
- reference the slim build directory from CDK stack
- document how to create the Lambda artifact

## Testing
- `pytest -q`
- ❌ `pre-commit` *(failed to run: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686930b5455083338382cbe189e3c533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a script to automate packaging of the Lambda deployment bundle.
* **Documentation**
  * Updated documentation with instructions for building and packaging the Lambda artifact.
* **Chores**
  * Updated Lambda deployment process to use the new build output directory for code assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->