### PR TITLE
Pin dependencies

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib==2.131.0
+constructs==10.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 authors = [{name = "Example", email = "example@example.com"}]
 requires-python = ">=3.10"
 dependencies = [
-    "argon2-cffi",
-    "boto3",
-    "redis",
-    "amazon-braket-sdk",
+    "argon2-cffi==25.1.0",
+    "boto3==1.34.0",
+    "redis==5.0.4",
+    "amazon-braket-sdk==1.80.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-argon2-cffi
-ruff
-boto3
-redis
-pytest-cov
-amazon-braket-sdk
+argon2-cffi==25.1.0
+ruff==0.3.4
+boto3==1.34.0
+redis==5.0.4
+pytest-cov==5.0.0
+amazon-braket-sdk==1.80.0


### PR DESCRIPTION
## Summary
- pin runtime versions in requirements
- lock infra dependency versions
- pin project dependencies in pyproject.toml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686930b694b8833390b0c25a039aede9