### PR TITLE
Verify Braket measurement counts

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -159,6 +159,8 @@ class BraketBackend:
         result_bytes = bytearray()
         for bits, count in result.measurement_counts.items():
             result_bytes.extend(int(bits, 2).to_bytes(1, "big") * count)
+        if len(result_bytes) != self.num_bytes:
+            raise RuntimeError("measurement count mismatch")
         return bytes(result_bytes)
 
 


### PR DESCRIPTION
## Summary
- enforce that BraketBackend result byte count matches `num_bytes`
- raise error when measurement counts are inconsistent
- test incorrect measurement counts in BraketBackend

## Testing
- `pre-commit run --files src/qs_kdf/core.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686930b7bb4883338aaf7a4f4122989b