### PR TITLE
Add limits to CLI and lambda

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,9 @@ production.
 The repository ships with a static 32-byte pepper used for these examples.
 Replace it with your own secret when deploying.
 
+Passwords longer than 64 bytes or salts over 32 bytes are rejected by both
+the CLI and Lambda handler to keep memory usage predictable.
+
 ### Cloud mode
 
 Running with `--cloud` invokes the deployed Lambda. Set the following

--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -3,6 +3,8 @@
 import argparse
 import os
 
+from .constants import MAX_PASSWORD_BYTES, MAX_SALT_BYTES
+
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
 
@@ -35,6 +37,12 @@ def main(argv: list[str] | None = None) -> int:
         raise argparse.ArgumentTypeError(
             f"invalid hex value for --salt: {args.salt}"
         ) from exc
+    if len(args.password.encode()) > MAX_PASSWORD_BYTES:
+        parser.error(
+            f"password exceeds {MAX_PASSWORD_BYTES} bytes"
+        )
+    if len(salt) > MAX_SALT_BYTES:
+        parser.error(f"salt exceeds {MAX_SALT_BYTES} bytes")
     if args.cmd == "hash":
         if args.cloud:
             required = ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"]

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -1,3 +1,7 @@
 """Constant values used across the quantum stretch KDF."""
 
 PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo
+
+# Maximum lengths enforced by the CLI and Lambda handler
+MAX_PASSWORD_BYTES = 64
+MAX_SALT_BYTES = 32

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping, Protocol
 
-from .constants import PEPPER
+from .constants import MAX_PASSWORD_BYTES, MAX_SALT_BYTES, PEPPER
 
 _warmed_up = False
 _warm_up_lock = threading.Lock()
@@ -322,6 +322,12 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     )
     cache = RedisCache(r)
     seed = bytes.fromhex(salt_hex)
+    if len(password.encode()) > MAX_PASSWORD_BYTES:
+        raise ValueError(
+            f"password may not exceed {MAX_PASSWORD_BYTES} bytes"
+        )
+    if len(seed) > MAX_SALT_BYTES:
+        raise ValueError(f"salt may not exceed {MAX_SALT_BYTES} bytes")
     key = hashlib.sha256(seed).hexdigest()
 
     device = AwsDevice("arn:aws:braket:::device/qpu/ionq/ionQdevice")


### PR DESCRIPTION
## Summary
- enforce password/salt size constraints in CLI and Lambda
- document the limits in the getting started guide

## Testing
- `pre-commit run --files src/qs_kdf/constants.py src/qs_kdf/cli.py src/qs_kdf/core.py docs/getting-started.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686930bb42fc83338e3702444e5bc2c2