### PR TITLE
Update CLI exit code for verify failure

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -15,7 +15,7 @@ def main(argv: list[str] | None = None) -> int:
         argv: Optional list of command-line arguments.
 
     Returns:
-        int: ``0`` on success.
+        int: ``0`` on success, ``1`` when password verification fails.
     """
 
     parser = argparse.ArgumentParser(prog="qs_kdf")
@@ -69,6 +69,7 @@ def main(argv: list[str] | None = None) -> int:
         backend = LocalBackend()
         ok = verify_password(args.password, salt, digest, backend=backend)
         print("OK" if ok else "NOPE")
+        return 0 if ok else 1
     return 0
 
 

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -114,17 +114,22 @@ def test_cli_verify_nope():
     backend = qs_kdf.LocalBackend()
     salt = b"\x05" * 16
     qs_kdf.hash_password("pw", salt, backend=backend)
-    out = _run_cli(
-        [
-            "verify",
-            "pw",
-            "--salt",
-            "05" * 16,
-            "--digest",
-            "00" * 32,
-        ]
-    )
-    assert out == "NOPE"
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), pytest.raises(SystemExit) as excinfo:
+        raise SystemExit(
+            cli_module.main(
+                [
+                    "verify",
+                    "pw",
+                    "--salt",
+                    "05" * 16,
+                    "--digest",
+                    "00" * 32,
+                ]
+            )
+        )
+    assert buf.getvalue().strip() == "NOPE"
+    assert excinfo.value.code == 1
 
 
 def test_braket_backend(monkeypatch):


### PR DESCRIPTION
## Summary
- return exit code `1` when password verification fails
- document the new exit status in the CLI
- test exit status on verify failure

## Testing
- `pre-commit run --files src/qs_kdf/cli.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68693b45c4188333b690e8b58499d5f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now correctly exits with a non-zero status code when password verification fails, improving error signaling.

* **Documentation**
  * Updated the documentation for the CLI to clarify its exit codes on success and failure.

* **Tests**
  * Enhanced tests to verify both the output message and the exit status code when password verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->