### PR TITLE
Add --version flag and expose package version

### DIFF
--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -1,6 +1,13 @@
 """Quantum stretch KDF package."""
 
-from .cli import main as cli
+from pathlib import Path
+
+import tomllib
+
+_pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+with _pyproject.open("rb") as f:
+    __version__ = tomllib.load(f)["project"]["version"]
+
 from .core import (
     BraketBackend,
     LocalBackend,
@@ -9,6 +16,7 @@ from .core import (
     qstretch,
     verify_password,
 )
+from .cli import main as cli
 from .test_backend import TestBackend
 
 __all__ = [
@@ -20,4 +28,5 @@ __all__ = [
     "verify_password",
     "LocalBackend",
     "BraketBackend",
+    "__version__",
 ]

--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -1,8 +1,8 @@
 """Quantum stretch KDF package."""
 
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-
-import tomllib
+import re
 
 from .core import (
     BraketBackend,
@@ -16,8 +16,20 @@ from .cli import main as cli
 from .test_backend import TestBackend
 
 _pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
-with _pyproject.open("rb") as f:
-    __version__ = tomllib.load(f)["project"]["version"]
+
+
+def _read_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    if not match:
+        raise RuntimeError("version not found in pyproject.toml")
+    return match.group(1)
+
+
+try:
+    __version__ = version("argon2-quantum")
+except PackageNotFoundError:
+    __version__ = _read_version(_pyproject)
 
 __all__ = [
     "lambda_handler",

--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -4,10 +4,6 @@ from pathlib import Path
 
 import tomllib
 
-_pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
-with _pyproject.open("rb") as f:
-    __version__ = tomllib.load(f)["project"]["version"]
-
 from .core import (
     BraketBackend,
     LocalBackend,
@@ -18,6 +14,10 @@ from .core import (
 )
 from .cli import main as cli
 from .test_backend import TestBackend
+
+_pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+with _pyproject.open("rb") as f:
+    __version__ = tomllib.load(f)["project"]["version"]
 
 __all__ = [
     "lambda_handler",

--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -3,6 +3,8 @@
 import argparse
 import os
 
+import qs_kdf
+
 from .constants import MAX_PASSWORD_BYTES, MAX_SALT_BYTES
 
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
@@ -19,6 +21,7 @@ def main(argv: list[str] | None = None) -> int:
     """
 
     parser = argparse.ArgumentParser(prog="qs_kdf")
+    parser.add_argument("--version", action="version", version=qs_kdf.__version__)
     sub = parser.add_subparsers(dest="cmd", required=True)
     h = sub.add_parser("hash")
     h.add_argument("password")
@@ -38,9 +41,7 @@ def main(argv: list[str] | None = None) -> int:
             f"invalid hex value for --salt: {args.salt}"
         ) from exc
     if len(args.password.encode()) > MAX_PASSWORD_BYTES:
-        parser.error(
-            f"password exceeds {MAX_PASSWORD_BYTES} bytes"
-        )
+        parser.error(f"password exceeds {MAX_PASSWORD_BYTES} bytes")
     if len(salt) > MAX_SALT_BYTES:
         parser.error(f"salt exceeds {MAX_SALT_BYTES} bytes")
     if args.cmd == "hash":

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -56,6 +56,14 @@ def _run_cli(argv: list[str]) -> str:
     return buf.getvalue().strip()
 
 
+def test_cli_version_flag(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(["--version"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert qs_kdf.__version__ in captured.out
+
+
 def test_cli_output_local():
     out = _run_cli(["hash", "pw", "--salt", "01" * 16])
     assert out


### PR DESCRIPTION
## Summary
- expose `__version__` from `pyproject.toml`
- add `--version` CLI flag
- test the version output

## Testing
- `pre-commit run --files src/qs_kdf/__init__.py src/qs_kdf/cli.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693b4a6fcc83338df75e7573be591b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to display the current package version using the `--version` flag.
  * The package now provides version information programmatically via a `__version__` attribute.

* **Tests**
  * Introduced a new test to verify the correct behavior of the CLI `--version` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->