### PR TITLE
Add migration fallback docs

### DIFF
--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -8,3 +8,8 @@ fault-tolerant QPUs exist the advantage disappears.
 A two-hash migration stores both the classical digest and the quantum-extended
 version. The extra step can later be removed without requiring all users to
 reset their passwords.
+
+During rollout, append the quantum digest whenever credentials are updated.
+Verification should gracefully fall back to standard Argon2 hashing if the
+quantum step cannot run, allowing operation in offline or restricted
+environments.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -23,3 +23,14 @@ possible.
 Passwords are hashed with the old method and the quantum-extended version in
 parallel. After all users rotate their credentials, the quantum layer can be
 removed without disrupting verification.
+
+## Operational Tasks
+
+* **Cache Flush**: run `redis-cli FLUSHALL` to clear stored quantum bytes when
+  corruption is suspected or after a major upgrade.
+* **Pepper Rotation**: update the `QS_PEPPER` secret and redeploy the Lambda
+  function. Old peppers remain valid for 24 hours to avoid lockouts.
+* **Redeploy Steps**: build the container, push to ECR and run `make deploy`
+  from the CI runner. Ensure the Step Function points at the new image tag.
+* **Monitoring Tips**: watch CloudWatch for Braket errors, Redis latency and
+  container restarts. Alert on sustained spikes or missing metrics.


### PR DESCRIPTION
## Summary
- expand quantum KDF one‑pager with fallback instructions
- add operational tasks section to the runbook

## Testing
- `pytest -q`
- `pre-commit run --files docs/one-pager.md docs/runbook.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693ce146548333900e40a764cf82e2