### PR TITLE
Add docs for lambda packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Deploy with `cdk deploy` or use the included Terraform module:
 terraform -chdir=terraform apply
 ```
 More background is available in the documents under [`docs/`](docs/).
+See [docs/lambda-build.md](docs/lambda-build.md) for instructions on
+packaging the Lambda function.
 
 ## Development
 Use Python 3.10 or newer. Install the hooks once:

--- a/docs/lambda-build.md
+++ b/docs/lambda-build.md
@@ -1,0 +1,9 @@
+# Packaging the Lambda Function
+
+`scripts/package_lambda.sh` bundles the source code and Python dependencies into
+`build/lambda.zip`. This archive is ready for manual upload to AWS Lambda or for
+use by deployment tooling.
+
+Run the script whenever you update the dependencies in `requirements.txt` or
+change code under `src/`. The script installs the packages into
+`build/lambda/`, copies the project sources, and creates the zip file.


### PR DESCRIPTION
## Summary
- document `scripts/package_lambda.sh`
- cross-link lambda build steps from README

## Testing
- `pre-commit run --files README.md docs/lambda-build.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693ce2c58c8333ba062df57dbaa7db