### PR TITLE
Refactor lambda handler env checks

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -302,6 +302,7 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
 
     Raises:
         KeyError: If ``event`` is missing required fields.
+        RuntimeError: If required environment variables are absent.
         TypeError: If ``event`` is not a valid mapping or strings.
     """
     import boto3  # type: ignore
@@ -311,6 +312,14 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     evt = event if isinstance(event, HashEvent) else HashEvent.from_dict(event)
     salt_hex = evt.salt
     password = evt.password
+
+    required_vars = ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"]
+    missing = [var for var in required_vars if var not in os.environ]
+    if missing:
+        raise RuntimeError(
+            "missing environment variables: " + ", ".join(sorted(missing))
+        )
+
     kms_key = os.environ["KMS_KEY_ID"]
     cipher_b64 = os.environ["PEPPER_CIPHERTEXT"]
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -194,8 +194,9 @@ def test_lambda_handler_missing_env(monkeypatch, var, _env):
     _setup_modules(monkeypatch, kms, redis_client, device)
 
     monkeypatch.delenv(var, raising=False)
-    with pytest.raises(KeyError):
+    with pytest.raises(RuntimeError) as exc:
         lambda_handler(asdict(HashEvent(password="pw", salt="22" * 16)), None)
+    assert var in str(exc.value)
 
 
 def test_lambda_handler_redis_options(monkeypatch, _env):


### PR DESCRIPTION
## Summary
- handle missing lambda environment variables at once
- raise RuntimeError when env vars are absent
- test new error message

## Testing
- `python -m pre_commit run --files src/qs_kdf/core.py tests/test_lambda_handler.py` *(fails: No module named pre_commit)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686943c61fe883339901182aa64ff1c0