### PR TITLE
Add device ARN override for BraketBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ $ python -m qs_kdf hash mypassword
 Running without `--cloud` keeps all computation local using the built-in
 simulator backend.
 
+The ``BraketBackend`` defaults to the IonQ QPU but accepts a ``device_arn``
+parameter if you wish to target a different device.
+
 The stack in [`infra/qs_kdf_stack.py`](infra/qs_kdf_stack.py) can be deployed
 with a single command:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,4 +123,5 @@ Follow these steps to provision the cloud resources:
 The random bytes are fetched from AWS Braket by running a tiny circuit. Ensure
 your credentials permit Braket execution. See the
 [Braket documentation](https://docs.aws.amazon.com/braket/)
-for further details.
+for further details. ``BraketBackend`` uses the IonQ device by default but you
+may pass ``device_arn`` to select a different ARN.

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -89,6 +89,7 @@ class BraketBackend:
     """Backend fetching random bytes from AWS Braket."""
 
     device: Any | None = None
+    device_arn: str = "arn:aws:braket:::device/qpu/ionq/ionQdevice"
     num_bytes: int = 10
     _init_error: Exception | None = field(init=False, default=None)
 
@@ -100,7 +101,8 @@ class BraketBackend:
 
         Notes:
             ``self.device`` remains ``None`` when the SDK is missing and
-            :meth:`run` will raise :class:`RuntimeError`.
+            :meth:`run` will raise :class:`RuntimeError`. Set
+            ``device_arn`` to select a different quantum device.
         """
 
         if not isinstance(self.num_bytes, int) or self.num_bytes <= 0:
@@ -117,9 +119,7 @@ class BraketBackend:
                 return
 
             try:
-                self.device = AwsDevice(
-                    "arn:aws:braket:::device/qpu/ionq/ionQdevice"
-                )
+                self.device = AwsDevice(self.device_arn)
             except NoCredentialsError as exc:  # pragma: no cover - optional
                 logging.getLogger(__name__).error("AWS credentials missing: %s", exc)
                 self._init_error = exc


### PR DESCRIPTION
## Summary
- allow BraketBackend to accept a custom `device_arn`
- create the AwsDevice from `device_arn` when none supplied
- document the parameter
- verify the ARN is used in tests

## Testing
- `pre-commit run --files README.md docs/getting-started.md src/qs_kdf/core.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686943d4e4708333bd85233f03d7cfd0