### PR TITLE
Switch setup and CI to UV

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -6,14 +6,14 @@ export CODEX_ENV_PYTHON_VERSION="3.12"
 export CODEX_ENV_NODE_VERSION="20"
 source /opt/codex/setup_universal.sh
 
-python -m venv venv
+uv venv venv
 source venv/bin/activate
 
-PIP_ARGS="--no-index --find-links=/opt/wheels"
+UV_ARGS="--no-index --find-links=/opt/wheels"
 
-pip install ${PIP_ARGS} -r requirements.txt
-pip install ${PIP_ARGS} -r infra/requirements.txt
-pip install ${PIP_ARGS} -e .
-pip install ${PIP_ARGS} pre-commit
+uv pip install ${UV_ARGS} -r requirements.txt
+uv pip install ${UV_ARGS} -r infra/requirements.txt
+uv pip install ${UV_ARGS} -e .
+uv pip install ${UV_ARGS} pre-commit
 
 pre-commit install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          uv pip install -r requirements.txt
-          uv pip install -r infra/requirements.txt
-          uv pip install .
-          uv pip install ruff
-          uv pip install bandit
+          uv pip install --system -r requirements.txt
+          uv pip install --system -r infra/requirements.txt
+          uv pip install --system .
+          uv pip install --system ruff
+          uv pip install --system bandit
       - name: Ruff
         run: ruff check .
       - name: Bandit
         run: bandit -c .bandit.yml -r src/qs_kdf
       - name: Tests
         run: |
-          uv pip install pytest pytest-cov
+          uv pip install --system pytest pytest-cov
           pytest --cov=src --cov-report=xml --cov-fail-under=70
       - name: Upload coverage
         if: env.CODECOV_TOKEN != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,19 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r infra/requirements.txt
-          pip install .
-          pip install ruff
-          pip install bandit
+          pip install uv
+          uv pip install -r requirements.txt
+          uv pip install -r infra/requirements.txt
+          uv pip install .
+          uv pip install ruff
+          uv pip install bandit
       - name: Ruff
         run: ruff check .
       - name: Bandit
         run: bandit -c .bandit.yml -r src/qs_kdf
       - name: Tests
         run: |
-          pip install pytest pytest-cov
+          uv pip install pytest pytest-cov
           pytest --cov=src --cov-report=xml --cov-fail-under=70
       - name: Upload coverage
         if: env.CODECOV_TOKEN != ''


### PR DESCRIPTION
## Summary
- update `.codex/setup.sh` to use `uv`
- move CI installation steps over to `uv`

## Testing
- `pre-commit run --files .codex/setup.sh .github/workflows/ci.yml` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686942be0c40833381b4776245b11303