### PR TITLE
Add Dockerfile and doc usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+ENTRYPOINT ["qs_kdf"]
+CMD ["--help"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,23 @@ pip install .
 # argon2-cffi is installed as a required dependency
 ```
 
+### Docker
+
+Build the container image from the project root:
+
+```bash
+docker build -t qs_kdf .
+```
+
+Run the CLI by passing arguments to `docker run`:
+
+```bash
+docker run --rm qs_kdf hash "hunter2" --salt 0011223344556677
+```
+
+The image installs the package and exposes the ``qs_kdf`` command as the
+entrypoint. Additional flags such as ``--cloud`` are forwarded unchanged.
+
 ## Hash a Password
 
 ```bash


### PR DESCRIPTION
## Summary
- add Dockerfile for CLI usage
- document Docker commands in getting-started docs

## Testing
- `pytest -q`
- ❌ `pre-commit run --files Dockerfile docs/getting-started.md` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_686943c3da2c833395a64b665916c778