### PR TITLE
Add argon2 tuning options to CLI

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -24,11 +24,17 @@ def main(argv: list[str] | None = None) -> int:
     h.add_argument("password")
     h.add_argument("--salt")
     h.add_argument("--cloud", action="store_true")
+    h.add_argument("--time-cost", type=int, default=3)
+    h.add_argument("--memory-cost", type=int, default=262_144)
+    h.add_argument("--parallelism", type=int, default=4)
 
     v = sub.add_parser("verify")
     v.add_argument("password")
     v.add_argument("--salt", required=True)
     v.add_argument("--digest", required=True)
+    v.add_argument("--time-cost", type=int, default=3)
+    v.add_argument("--memory-cost", type=int, default=262_144)
+    v.add_argument("--parallelism", type=int, default=4)
 
     args = parser.parse_args(argv)
     if args.salt is None:
@@ -60,7 +66,14 @@ def main(argv: list[str] | None = None) -> int:
             digest_hex = response["digest"]
         else:
             backend = LocalBackend()
-            digest_hex = hash_password(args.password, salt, backend=backend).hex()
+            digest_hex = hash_password(
+                args.password,
+                salt,
+                backend=backend,
+                time_cost=args.time_cost,
+                memory_cost=args.memory_cost,
+                parallelism=args.parallelism,
+            ).hex()
         if args.salt is None:
             print(f"{salt_hex} {digest_hex}")
         else:
@@ -73,7 +86,15 @@ def main(argv: list[str] | None = None) -> int:
                 f"invalid hex value for --digest: {args.digest}"
             ) from exc
         backend = LocalBackend()
-        ok = verify_password(args.password, salt, digest, backend=backend)
+        ok = verify_password(
+            args.password,
+            salt,
+            digest,
+            backend=backend,
+            time_cost=args.time_cost,
+            memory_cost=args.memory_cost,
+            parallelism=args.parallelism,
+        )
         print("OK" if ok else "NOPE")
         return 0 if ok else 1
     return 0

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -169,6 +169,9 @@ def hash_password(
     salt: bytes,
     backend: Backend | None = None,
     pepper: bytes | None = None,
+    time_cost: int = 3,
+    memory_cost: int = 262_144,
+    parallelism: int = 4,
 ) -> bytes:
     """Compute Argon2id digest with quantum salt bytes.
 
@@ -177,6 +180,9 @@ def hash_password(
         salt: Salt bytes.
         backend: Backend providing quantum randomness.
         pepper: Optional pepper value.
+        time_cost: Argon2 time cost.
+        memory_cost: Argon2 memory cost.
+        parallelism: Argon2 parallelism.
 
     Returns:
         bytes: Final digest bytes.
@@ -192,9 +198,9 @@ def hash_password(
     digest = hash_secret_raw(
         password.encode(),
         new_salt,
-        time_cost=3,
-        memory_cost=262_144,
-        parallelism=4,
+        time_cost=time_cost,
+        memory_cost=memory_cost,
+        parallelism=parallelism,
         hash_len=32,
         type=Type.ID,
     )
@@ -207,6 +213,9 @@ def verify_password(
     digest: bytes,
     backend: Backend | None = None,
     pepper: bytes | None = None,
+    time_cost: int = 3,
+    memory_cost: int = 262_144,
+    parallelism: int = 4,
 ) -> bool:
     """Check that password and salt produce ``digest``.
 
@@ -216,11 +225,22 @@ def verify_password(
         digest: Expected digest bytes.
         backend: Backend providing quantum randomness.
         pepper: Optional pepper value.
+        time_cost: Argon2 time cost.
+        memory_cost: Argon2 memory cost.
+        parallelism: Argon2 parallelism.
 
     Returns:
         bool: ``True`` on match, ``False`` otherwise.
     """
-    candidate = hash_password(password, salt, backend=backend, pepper=pepper)
+    candidate = hash_password(
+        password,
+        salt,
+        backend=backend,
+        pepper=pepper,
+        time_cost=time_cost,
+        memory_cost=memory_cost,
+        parallelism=parallelism,
+    )
     return secrets.compare_digest(candidate, digest)
 
 


### PR DESCRIPTION
## Summary
- add optional tuning arguments to CLI
- forward argon2 cost parameters to library
- extend `hash_password` and `verify_password` signatures
- test CLI with custom options

## Testing
- `python -m pre_commit run --files src/qs_kdf/cli.py src/qs_kdf/core.py tests/test_qs_kdf.py` *(fails: No module named pre_commit)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686943fc4aa0833390314e5b34efe4eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing time cost, memory cost, and parallelism parameters in password hashing and verification via the command-line interface.
* **Tests**
  * Introduced tests to ensure the CLI correctly handles and forwards custom hashing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->