### PR TITLE
Add Braket device options to CLI

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -24,6 +24,10 @@ def main(argv: list[str] | None = None) -> int:
     h.add_argument("password")
     h.add_argument("--salt")
     h.add_argument("--cloud", action="store_true")
+    h.add_argument(
+        "--device-arn", default="arn:aws:braket:::device/qpu/ionq/ionQdevice"
+    )
+    h.add_argument("--num-bytes", type=int, default=10)
     h.add_argument("--time-cost", type=int, default=3)
     h.add_argument("--memory-cost", type=int, default=262_144)
     h.add_argument("--parallelism", type=int, default=4)
@@ -61,7 +65,13 @@ def main(argv: list[str] | None = None) -> int:
                     "--cloud requires environment variables: " + ", ".join(missing)
                 )
             response = lambda_handler(
-                {"password": args.password, "salt": salt_hex}, None
+                {
+                    "password": args.password,
+                    "salt": salt_hex,
+                    "device_arn": args.device_arn,
+                    "num_bytes": args.num_bytes,
+                },
+                None,
             )
             digest_hex = response["digest"]
         else:

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -315,6 +315,8 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
 
     Args:
         event: Invocation payload containing ``salt`` and ``password``.
+            Optional keys ``"device_arn"`` and ``"num_bytes"`` select the
+            Braket device and the number of bytes to fetch.
         _ctx: Lambda context object (unused).
 
     Returns:
@@ -365,15 +367,32 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     cache = RedisCache(r)
     seed = bytes.fromhex(salt_hex)
     if len(password.encode()) > MAX_PASSWORD_BYTES:
-        raise ValueError(
-            f"password may not exceed {MAX_PASSWORD_BYTES} bytes"
-        )
+        raise ValueError(f"password may not exceed {MAX_PASSWORD_BYTES} bytes")
     if len(seed) > MAX_SALT_BYTES:
         raise ValueError(f"salt may not exceed {MAX_SALT_BYTES} bytes")
     key = hashlib.sha256(seed).hexdigest()
 
-    device = AwsDevice("arn:aws:braket:::device/qpu/ionq/ionQdevice")
-    backend = BraketBackend(device=device)
+    device_arn = (
+        getattr(evt, "device_arn", None)
+        if isinstance(event, HashEvent)
+        else event.get("device_arn")
+        if isinstance(event, Mapping)
+        else None
+    )
+    num_bytes = (
+        getattr(evt, "num_bytes", None)
+        if isinstance(event, HashEvent)
+        else event.get("num_bytes")
+        if isinstance(event, Mapping)
+        else None
+    )
+    if num_bytes is not None:
+        num_bytes = int(num_bytes)
+    else:
+        num_bytes = 10
+    device_arn = device_arn or "arn:aws:braket:::device/qpu/ionq/ionQdevice"
+    device = AwsDevice(device_arn)
+    backend = BraketBackend(device=device, device_arn=device_arn, num_bytes=num_bytes)
 
     def _producer() -> bytes:
         return backend.run(seed)

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -82,6 +82,35 @@ def test_cli_output_cloud(monkeypatch):
     assert out == "deadbeef"
 
 
+def test_cli_device_options(monkeypatch):
+    captured: dict[str, dict] = {}
+
+    def fake_handler(event: dict, _ctx: object) -> dict:
+        captured["event"] = event
+        return {"digest": "bead"}
+
+    monkeypatch.setattr(cli_module, "lambda_handler", fake_handler)
+    monkeypatch.setenv("KMS_KEY_ID", "k")
+    monkeypatch.setenv("PEPPER_CIPHERTEXT", "c")
+    monkeypatch.setenv("REDIS_HOST", "r")
+    out = _run_cli(
+        [
+            "hash",
+            "pw",
+            "--salt",
+            "01" * 16,
+            "--cloud",
+            "--device-arn",
+            "arn:custom",
+            "--num-bytes",
+            "2",
+        ]
+    )
+    assert out == "bead"
+    assert captured["event"]["device_arn"] == "arn:custom"
+    assert captured["event"]["num_bytes"] == 2
+
+
 def test_cli_custom_params(monkeypatch):
     called: dict[str, tuple[int, int, int]] = {}
 


### PR DESCRIPTION
## Summary
- support `--device-arn` and `--num-bytes` on `hash`
- wire options through to `BraketBackend`
- test CLI usage of new options

## Testing
- `pre-commit run --files src/qs_kdf/cli.py src/qs_kdf/core.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694cecf5f48333b9d59eefa762fcda