### PR TITLE
Add opt-in warm-up control

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ $ python -m qs_kdf hash mypassword
 Running without `--cloud` keeps all computation local using the built-in
 simulator backend.
 
+Set ``QS_WARMUP=1`` or call ``qs_kdf.warm_up()`` to preload Argon2 memory
+for consistent benchmarking.
+
 The ``BraketBackend`` defaults to the IonQ QPU but accepts a ``device_arn``
 parameter if you wish to target a different device.
 

--- a/src/qs_kdf/__init__.py
+++ b/src/qs_kdf/__init__.py
@@ -7,6 +7,7 @@ import re
 from .core import (
     BraketBackend,
     LocalBackend,
+    warm_up,
     hash_password,
     lambda_handler,
     qstretch,
@@ -37,6 +38,7 @@ __all__ = [
     "TestBackend",
     "qstretch",
     "hash_password",
+    "warm_up",
     "verify_password",
     "LocalBackend",
     "BraketBackend",

--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -37,6 +37,12 @@ def _warm_up() -> None:
         _warmed_up = True
 
 
+def warm_up() -> None:
+    """Public wrapper enabling explicit warm-up."""
+
+    _warm_up()
+
+
 try:
     from argon2.low_level import Type, hash_secret_raw  # type: ignore
 except Exception as exc:  # pragma: no cover - enforce dependency
@@ -44,7 +50,8 @@ except Exception as exc:  # pragma: no cover - enforce dependency
         "argon2-cffi must be installed; run 'pip install argon2-cffi'"
     ) from exc
 
-_warm_up()
+if os.getenv("QS_WARMUP"):
+    _warm_up()
 
 
 class Backend(Protocol):
@@ -187,7 +194,6 @@ def hash_password(
     Returns:
         bytes: Final digest bytes.
     """
-    _warm_up()
     if backend is None:
         backend = LocalBackend()
     if pepper is None:
@@ -365,9 +371,7 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     cache = RedisCache(r)
     seed = bytes.fromhex(salt_hex)
     if len(password.encode()) > MAX_PASSWORD_BYTES:
-        raise ValueError(
-            f"password may not exceed {MAX_PASSWORD_BYTES} bytes"
-        )
+        raise ValueError(f"password may not exceed {MAX_PASSWORD_BYTES} bytes")
     if len(seed) > MAX_SALT_BYTES:
         raise ValueError(f"salt may not exceed {MAX_SALT_BYTES} bytes")
     key = hashlib.sha256(seed).hexdigest()

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,19 @@
+import importlib
+
+
+import qs_kdf.core as core
+
+
+def test_warm_up_env(monkeypatch):
+    monkeypatch.setenv("QS_WARMUP", "1")
+    importlib.reload(core)
+    assert core._warmed_up is True
+    monkeypatch.delenv("QS_WARMUP")
+    importlib.reload(core)
+
+
+def test_warm_up_function():
+    importlib.reload(core)
+    assert core._warmed_up is False
+    core.warm_up()
+    assert core._warmed_up is True


### PR DESCRIPTION
## Summary
- support warm-up via `QS_WARMUP` or `warm_up()`
- document warm-up option
- cover explicit warm-up in tests

## Testing
- `ruff check --fix src/qs_kdf/core.py src/qs_kdf/__init__.py tests/test_warmup.py`
- `ruff format src/qs_kdf/core.py src/qs_kdf/__init__.py tests/test_warmup.py`
- `bandit -c .bandit.yml -r src/qs_kdf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694d4127d88333b52f706c767c195a