### PR TITLE
Update cli exit handling

### DIFF
--- a/src/qsargon2.py
+++ b/src/qsargon2.py
@@ -23,4 +23,4 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    raise SystemExit(main())

--- a/tests/test_entry_script.py
+++ b/tests/test_entry_script.py
@@ -7,22 +7,27 @@ import sys
 import qsargon2
 
 
-def _run_cli(argv: list[str]) -> str:
+def _run_cli(argv: list[str]) -> tuple[int, str]:
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         old_argv = sys.argv
         sys.argv = ["qsargon2", *argv]
         try:
-            runpy.run_module("qsargon2", run_name="__main__")
+            code = 0
+            try:
+                runpy.run_module("qsargon2", run_name="__main__")
+            except SystemExit as exc:  # pragma: no cover - CLI exit
+                code = exc.code if exc.code is not None else 0
         finally:
             sys.argv = old_argv
-    return buf.getvalue().strip()
+    return code, buf.getvalue().strip()
 
 
 def test_entry_script_deterministic():
     salt = b"\x05" * 16
     salt_hex = salt.hex()
-    out1 = _run_cli(["pw", "--salt", salt_hex])
-    out2 = _run_cli(["pw", "--salt", salt_hex])
+    code1, out1 = _run_cli(["pw", "--salt", salt_hex])
+    code2, out2 = _run_cli(["pw", "--salt", salt_hex])
     expected = base64.b64encode(qsargon2.hash_password("pw", salt)).decode()
+    assert code1 == code2 == 0
     assert out1 == out2 == expected


### PR DESCRIPTION
## Summary
- call `SystemExit` from `qsargon2` entrypoint
- capture exit codes in entry script tests

## Testing
- `pre-commit run --files src/qsargon2.py tests/test_entry_script.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694d4221188333a25ce79ceb167723