### PR TITLE
Enforce secure Redis defaults

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,12 +45,14 @@ export KMS_KEY_ID=<kms-key-id>
 export PEPPER_CIPHERTEXT=<base64-ciphertext>
 export REDIS_HOST=<redis-endpoint>
 export REDIS_PORT=6379  # optional when using the default
+export REDIS_TLS=1      # disable with 0/false/no
 export REDIS_CERT_REQS=required  # none|optional|required
 ```
 
-``REDIS_CERT_REQS`` defaults to ``required``. Set it to ``none`` to skip
-certificate validation or ``optional`` to allow failures while keeping TLS
-enabled.
+``REDIS_TLS`` defaults to ``1`` and disabling it is discouraged.
+``REDIS_CERT_REQS`` defaults to ``required``. Setting ``none`` disables
+certificate validation and is unsafe outside tests. ``optional`` allows
+failures while keeping TLS enabled.
 
 For local testing omit `--cloud` and these variables are ignored. Running in
 cloud mode requires them to be present in the Lambda configuration or your

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,11 +135,14 @@ Follow these steps to provision the cloud resources:
    export PEPPER_CIPHERTEXT=<base64-ciphertext>
    export REDIS_HOST=<redis-endpoint>
    export REDIS_PORT=6379  # optional when using the default port
+   export REDIS_TLS=1      # disable with 0/false/no
    export REDIS_CERT_REQS=required  # none|optional|required
    ```
 
-``REDIS_CERT_REQS`` defaults to ``required``. Set it to ``none`` to skip
-verification or ``optional`` to keep TLS active when verification fails.
+``REDIS_TLS`` defaults to ``1``. Disabling TLS is strongly discouraged.
+``REDIS_CERT_REQS`` defaults to ``required``. Setting it to ``none`` skips
+certificate verification and is unsafe outside tests. ``optional`` allows
+failures while keeping TLS enabled.
 
 The random bytes are fetched from AWS Braket by running a tiny circuit. Ensure
 your credentials permit Braket execution. See the

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -227,3 +227,16 @@ def test_lambda_handler_unverified_tls(monkeypatch, _env):
     lambda_handler(event, None)
 
     assert redis_module.ssl_cert_reqs is None
+
+
+def test_lambda_handler_unverified_tls_rejected(monkeypatch, _env):
+    monkeypatch.setenv("REDIS_CERT_REQS", "none")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    redis_client = FakeRedisClient()
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("10101010")
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = asdict(HashEvent(password="pw", salt="55" * 16))
+    with pytest.raises(RuntimeError):
+        lambda_handler(event, None)


### PR DESCRIPTION
## Summary
- enforce TLS by default in `lambda_handler`
- raise error when disabling certificate checks outside tests
- document `REDIS_TLS` and warn against disabling TLS or verification
- test rejection when cert verification is disabled

## Testing
- `pytest -q`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686963dff78083339f562d7365edb9b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and getting started guides to clarify Redis TLS environment variables, including new details on enabling/disabling TLS and certificate verification options.
* **Bug Fixes**
  * Improved runtime safety by preventing insecure Redis TLS configurations outside of test environments.
* **Tests**
  * Added a test to ensure that unverified TLS connections are rejected when not running in a test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->