### PR TITLE
Enforce byte count limits

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -5,7 +5,7 @@ import os
 
 import qs_kdf
 
-from .constants import MAX_PASSWORD_BYTES, MAX_SALT_BYTES
+from .constants import MAX_PASSWORD_BYTES, MAX_SALT_BYTES, MAX_NUM_BYTES
 
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
@@ -60,6 +60,10 @@ def main(argv: list[str] | None = None) -> int:
     if len(salt) > MAX_SALT_BYTES:
         parser.error(f"salt exceeds {MAX_SALT_BYTES} bytes")
     if args.cmd == "hash":
+        if args.num_bytes <= 0:
+            parser.error("--num-bytes must be a positive integer")
+        if args.num_bytes > MAX_NUM_BYTES:
+            parser.error(f"--num-bytes may not exceed {MAX_NUM_BYTES}")
         if args.cloud:
             required = ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"]
             missing = [v for v in required if v not in os.environ]

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -5,3 +5,4 @@ PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo
 # Maximum lengths enforced by the CLI and Lambda handler
 MAX_PASSWORD_BYTES = 64
 MAX_SALT_BYTES = 32
+MAX_NUM_BYTES = 100


### PR DESCRIPTION
## Summary
- add `MAX_NUM_BYTES` constant
- validate BraketBackend `num_bytes` against the limit
- enforce same maximum in CLI and Lambda handler
- test the limit across backend, CLI and Lambda

## Testing
- `pre-commit run --files src/qs_kdf/constants.py src/qs_kdf/core.py src/qs_kdf/cli.py tests/test_qs_kdf.py tests/test_lambda_handler.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686963e15e6883339596382f9a296791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure the number of bytes requested does not exceed a set maximum and is greater than zero in both the CLI and backend.
  * Introduced a new maximum bytes limit for hashing operations.

* **Bug Fixes**
  * Improved error handling for invalid byte size inputs, providing clearer error messages when limits are exceeded.

* **Tests**
  * Added and updated tests to verify enforcement of the maximum bytes limit and correct error handling for invalid input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->