### PR TITLE
Add CLI parameter limits

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -5,7 +5,16 @@ import os
 
 import qs_kdf
 
-from .constants import MAX_PASSWORD_BYTES, MAX_SALT_BYTES
+from .constants import (
+    MAX_PASSWORD_BYTES,
+    MAX_SALT_BYTES,
+    MIN_TIME_COST,
+    MAX_TIME_COST,
+    MIN_MEMORY_COST,
+    MAX_MEMORY_COST,
+    MIN_PARALLELISM,
+    MAX_PARALLELISM,
+)
 
 from .core import LocalBackend, hash_password, lambda_handler, verify_password
 
@@ -59,6 +68,18 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"password exceeds {MAX_PASSWORD_BYTES} bytes")
     if len(salt) > MAX_SALT_BYTES:
         parser.error(f"salt exceeds {MAX_SALT_BYTES} bytes")
+    if not (MIN_TIME_COST <= args.time_cost <= MAX_TIME_COST):
+        parser.error(
+            f"--time-cost must be between {MIN_TIME_COST} and {MAX_TIME_COST}"
+        )
+    if not (MIN_MEMORY_COST <= args.memory_cost <= MAX_MEMORY_COST):
+        parser.error(
+            f"--memory-cost must be between {MIN_MEMORY_COST} and {MAX_MEMORY_COST}"
+        )
+    if not (MIN_PARALLELISM <= args.parallelism <= MAX_PARALLELISM):
+        parser.error(
+            f"--parallelism must be between {MIN_PARALLELISM} and {MAX_PARALLELISM}"
+        )
     if args.cmd == "hash":
         if args.cloud:
             required = ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"]

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -5,3 +5,13 @@ PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for demo
 # Maximum lengths enforced by the CLI and Lambda handler
 MAX_PASSWORD_BYTES = 64
 MAX_SALT_BYTES = 32
+
+# Boundaries for Argon2 parameters
+MIN_TIME_COST = 1
+MAX_TIME_COST = 10
+
+MIN_MEMORY_COST = 32
+MAX_MEMORY_COST = 1024 * 1024
+
+MIN_PARALLELISM = 1
+MAX_PARALLELISM = 8

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -491,3 +491,35 @@ def test_cli_cloud_missing_env(monkeypatch, missing):
 def test_braket_backend_invalid_num_bytes(value):
     with pytest.raises(ValueError):
         qs_kdf.BraketBackend(device=object(), num_bytes=value)
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--time-cost", "0"),
+        ("--time-cost", "11"),
+        ("--memory-cost", "31"),
+        ("--memory-cost", str(1024 * 1024 + 1)),
+        ("--parallelism", "0"),
+        ("--parallelism", "9"),
+    ],
+)
+def test_cli_param_limits_invalid(flag: str, value: str):
+    with pytest.raises(SystemExit):
+        cli_module.main(["hash", "pw", "--salt", "01" * 16, flag, value])
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--time-cost", "1"),
+        ("--time-cost", "10"),
+        ("--memory-cost", "32"),
+        ("--memory-cost", str(1024 * 1024)),
+        ("--parallelism", "1"),
+        ("--parallelism", "8"),
+    ],
+)
+def test_cli_param_limits_valid(flag: str, value: str):
+    out = _run_cli(["hash", "pw", "--salt", "01" * 16, flag, value])
+    assert out


### PR DESCRIPTION
## Summary
- enforce limits for time cost, memory cost and parallelism
- validate CLI parameters against these bounds
- test invalid and boundary values

## Testing
- `pre-commit run --files src/qs_kdf/constants.py src/qs_kdf/cli.py tests/test_qs_kdf.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686963e80430833385fe30ee5f7fe262