### PR TITLE
Ensure codecov token used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
@@ -33,11 +31,11 @@ jobs:
           uv pip install --system pytest pytest-cov
           pytest --cov=src --cov-report=xml --cov-fail-under=70
       - name: Upload coverage
-        if: env.CODECOV_TOKEN != ''
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: CDK Synth
         working-directory: infra
         run: cdk synth


### PR DESCRIPTION
## Summary
- fix the CI workflow to use repo secret directly when uploading coverage

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869841b128483338b192950c82d4712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to reference secrets directly for coverage uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->