### PR TITLE
Fix Codecov token evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
@@ -31,11 +33,11 @@ jobs:
           uv pip install --system pytest pytest-cov
           pytest --cov=src --cov-report=xml --cov-fail-under=70
       - name: Upload coverage
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
       - name: CDK Synth
         working-directory: infra
         run: cdk synth


### PR DESCRIPTION
## Summary
- fix Codecov upload step by using env var for token

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ad5111f883339bfeed847f4cd700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use an environment variable for the code coverage token, improving how the token is referenced and managed during coverage uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->