### PR TITLE
Handle invalid REDIS_PORT in lambda handler

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -371,10 +371,12 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
         "Plaintext"
     ]
 
-    redis_opts = {
-        "host": os.environ["REDIS_HOST"],
-        "port": int(os.environ.get("REDIS_PORT", "6379")),
-    }
+    redis_opts = {"host": os.environ["REDIS_HOST"]}
+    port_str = os.environ.get("REDIS_PORT", "6379")
+    try:
+        redis_opts["port"] = int(port_str)
+    except ValueError as exc:
+        raise RuntimeError("REDIS_PORT must be an integer") from exc
 
     if os.environ.get("REDIS_PASSWORD"):
         redis_opts["password"] = os.environ["REDIS_PASSWORD"]

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -226,3 +226,15 @@ def test_lambda_handler_invalid_cert_reqs(monkeypatch, _env):
     event = asdict(HashEvent(password="pw", salt="44" * 16))
     with pytest.raises(RuntimeError):
         lambda_handler(event, None)
+
+
+def test_lambda_handler_invalid_port(monkeypatch, _env):
+    monkeypatch.setenv("REDIS_PORT", "notint")
+    redis_client = FakeRedisClient()
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("10101010")
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = asdict(HashEvent(password="pw", salt="55" * 16))
+    with pytest.raises(RuntimeError, match="REDIS_PORT must be an integer"):
+        lambda_handler(event, None)


### PR DESCRIPTION
## Summary
- improve lambda_handler by validating REDIS_PORT
- add unit test for invalid port value

## Testing
- `pre-commit run --files src/qs_kdf/core.py tests/test_lambda_handler.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bf6bc3f08333958127509848bfbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid Redis port values, now displaying a clear error if the port is not an integer.

* **Tests**
  * Added a test to verify that an appropriate error is raised when the Redis port environment variable is set to a non-integer value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->