### PR TITLE
Add missing QS_PEPPER CLI test

### DIFF
--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -87,6 +87,15 @@ def test_cli_generates_salt(_pepper):
     assert verify_out == "OK"
 
 
+def test_cli_missing_pepper(monkeypatch, capsys):
+    monkeypatch.delenv("QS_PEPPER", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(["hash", "pw", "--salt", "01" * 16])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "QS_PEPPER environment variable required" in captured.err
+
+
 def test_cli_output_cloud(monkeypatch):
     def fake_handler(event: dict, _ctx: object) -> dict:
         return {"digest": "deadbeef"}


### PR DESCRIPTION
## Summary
- cover CLI failure when `QS_PEPPER` is unset

## Testing
- `pre-commit run --files tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bfa2e9ac8333b662bc8aa4eb98b5