### PR TITLE
Add QS_PEPPER length check

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -69,9 +69,7 @@ def main(argv: list[str] | None = None) -> int:
     if len(salt) > MAX_SALT_BYTES:
         parser.error(f"salt exceeds {MAX_SALT_BYTES} bytes")
     if not (MIN_TIME_COST <= args.time_cost <= MAX_TIME_COST):
-        parser.error(
-            f"--time-cost must be between {MIN_TIME_COST} and {MAX_TIME_COST}"
-        )
+        parser.error(f"--time-cost must be between {MIN_TIME_COST} and {MAX_TIME_COST}")
     if not (MIN_MEMORY_COST <= args.memory_cost <= MAX_MEMORY_COST):
         parser.error(
             f"--memory-cost must be between {MIN_MEMORY_COST} and {MAX_MEMORY_COST}"
@@ -105,6 +103,8 @@ def main(argv: list[str] | None = None) -> int:
             pepper = pepper_env.encode()
             if len(pepper) == 0:
                 parser.error("QS_PEPPER must not be empty")
+            if len(pepper) != 32:
+                parser.error("QS_PEPPER must be 32 bytes")
             backend = LocalBackend()
             digest_hex = hash_password(
                 args.password,
@@ -132,6 +132,8 @@ def main(argv: list[str] | None = None) -> int:
         pepper = pepper_env.encode()
         if len(pepper) == 0:
             parser.error("QS_PEPPER must not be empty")
+        if len(pepper) != 32:
+            parser.error("QS_PEPPER must be 32 bytes")
         backend = LocalBackend()
         ok = verify_password(
             args.password,

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -20,8 +20,10 @@ cli_module = importlib.import_module("qs_kdf.cli")
 def _pepper(monkeypatch):
     monkeypatch.setenv("QS_PEPPER", "x" * 32)
     import qs_kdf.constants as constants
+
     monkeypatch.setattr(constants, "PEPPER", b"x" * 32, raising=False)
     import qs_kdf.core as core
+
     monkeypatch.setattr(core, "PEPPER", b"x" * 32, raising=False)
 
 
@@ -484,6 +486,12 @@ def test_cli_invalid_salt(_pepper):
 def test_cli_invalid_digest(_pepper):
     with pytest.raises(argparse.ArgumentTypeError):
         cli_module.main(["verify", "pw", "--salt", "01" * 16, "--digest", "zz"])
+
+
+def test_cli_pepper_length(monkeypatch):
+    monkeypatch.setenv("QS_PEPPER", "short")
+    with pytest.raises(SystemExit):
+        cli_module.main(["hash", "pw", "--salt", "01" * 16])
 
 
 @pytest.mark.parametrize("missing", ["KMS_KEY_ID", "PEPPER_CIPHERTEXT", "REDIS_HOST"])


### PR DESCRIPTION
## Summary
- enforce 32-byte QS_PEPPER in CLI
- test invalid pepper length exits

## Testing
- `pytest -q`
- `pre-commit run --files src/qs_kdf/cli.py tests/test_qs_kdf.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bf7b4c7083339487a37bcc16d6da