### PR TITLE
Add REDIS config validation tests

### DIFF
--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -226,3 +226,22 @@ def test_lambda_handler_invalid_cert_reqs(monkeypatch, _env):
     event = asdict(HashEvent(password="pw", salt="44" * 16))
     with pytest.raises(RuntimeError):
         lambda_handler(event, None)
+
+
+@pytest.mark.parametrize(
+    "var,value",
+    [
+        ("REDIS_PORT", "not-int"),
+        ("REDIS_TLS", "maybe"),
+    ],
+)
+def test_lambda_handler_invalid_redis_env(monkeypatch, _env, var, value):
+    monkeypatch.setenv(var, value)
+    redis_client = FakeRedisClient()
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("10101010")
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = asdict(HashEvent(password="pw", salt="55" * 16))
+    with pytest.raises(RuntimeError):
+        lambda_handler(event, None)


### PR DESCRIPTION
## Summary
- validate `REDIS_PORT` and `REDIS_TLS` values in `lambda_handler`
- cover error cases via new parametrized test cases

## Testing
- `pre-commit run --files src/qs_kdf/core.py tests/test_lambda_handler.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bf703684833383b2a929dad4eebe