### PR TITLE
Clarify backend interface docstring

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -67,7 +67,10 @@ if os.getenv("QS_WARMUP"):
 
 class Backend(Protocol):
     def run(self, seed: bytes) -> bytes:
-        """Return one byte derived from ``seed``."""
+        """Return bytes derived from ``seed``.
+
+        Length of the returned bytes depends on the backend.
+        """
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- clarify length of returned bytes in `Backend.run` docstring

## Testing
- `pre-commit run --files src/qs_kdf/core.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bf948978833394751721dd919b26