### PR TITLE
Validate Redis port range in lambda handler

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -383,6 +383,8 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
         redis_opts["port"] = int(port_str)
     except ValueError as exc:
         raise RuntimeError("REDIS_PORT must be an integer") from exc
+    if not 1 <= redis_opts["port"] <= 65535:
+        raise RuntimeError("REDIS_PORT must be between 1 and 65535")
 
     if os.environ.get("REDIS_PASSWORD"):
         redis_opts["password"] = os.environ["REDIS_PASSWORD"]

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -238,3 +238,15 @@ def test_lambda_handler_invalid_port(monkeypatch, _env):
     event = asdict(HashEvent(password="pw", salt="55" * 16))
     with pytest.raises(RuntimeError, match="REDIS_PORT must be an integer"):
         lambda_handler(event, None)
+
+
+def test_lambda_handler_port_out_of_range(monkeypatch, _env):
+    monkeypatch.setenv("REDIS_PORT", "70000")
+    redis_client = FakeRedisClient()
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("10101010")
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = asdict(HashEvent(password="pw", salt="56" * 16))
+    with pytest.raises(RuntimeError, match="REDIS_PORT must be between 1 and 65535"):
+        lambda_handler(event, None)


### PR DESCRIPTION
## Summary
- enforce valid range for `REDIS_PORT` in `lambda_handler`
- test that invalid port numbers raise `RuntimeError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e3e60d9c8333b58aa7969de4faae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the Redis port number to ensure it falls within the valid range (1 to 65535). An error is now raised if the port is out of range.

* **Tests**
  * Added a test to verify that an appropriate error is raised when the Redis port is set outside the valid range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->