### PR TITLE
Clarify pepper usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ simulator backend.
 Set ``QS_WARMUP=1`` or call ``qs_kdf.warm_up()`` to preload Argon2 memory
 for consistent benchmarking.
 
+
 ### QS_PEPPER
 
-Local hashing fails unless ``QS_PEPPER`` is set to a 32-byte secret. Export
-your own value before invoking the CLI. See
-[docs/getting-started.md](docs/getting-started.md) for details.
+The pepper in [src/qs_kdf/constants.py](src/qs_kdf/constants.py) is
+included only so the examples run out of the box. Local hashing fails
+unless ``QS_PEPPER`` is set to a 32-byte secret. Export your own value
+before invoking the CLI. See
+[docs/getting-started.md](docs/getting-started.md) lines 55-57 and 67 for
+instructions on overriding ``QS_PEPPER``. Always set a unique 32-byte
+secret in any production environment.
 
 The ``BraketBackend`` defaults to the IonQ QPU but accepts a ``device_arn``
 parameter if you wish to target a different device.


### PR DESCRIPTION
## Summary
- explain that the pepper in constants.py is only for the examples
- link getting-started lines that show how to override `QS_PEPPER`
- advise using a unique 32-byte secret in production

## Testing
- `pytest -q`
- `pre-commit run --files README.md docs/getting-started.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e3e819d483338afdd776d4fd9282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for setting the `QS_PEPPER` environment variable, emphasizing the need for a unique 32-byte secret in production.
  * Updated guidance to reference specific documentation lines for overriding `QS_PEPPER`.
  * Added a strong recommendation to always set a custom pepper for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->