### PR TITLE
Add tests for HashEvent.from_dict

### DIFF
--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -238,3 +238,14 @@ def test_lambda_handler_invalid_port(monkeypatch, _env):
     event = asdict(HashEvent(password="pw", salt="55" * 16))
     with pytest.raises(RuntimeError, match="REDIS_PORT must be an integer"):
         lambda_handler(event, None)
+
+
+def test_hash_event_from_dict_non_mapping():
+    with pytest.raises(TypeError):
+        HashEvent.from_dict(["not", "mapping"])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("payload", [{"password": "pw"}, {"salt": "ff"}])
+def test_hash_event_from_dict_missing_fields(payload: dict):
+    with pytest.raises(KeyError):
+        HashEvent.from_dict(payload)


### PR DESCRIPTION
## Summary
- ensure `HashEvent.from_dict` raises on invalid types
- check missing field handling

## Testing
- `pre-commit run --files tests/test_lambda_handler.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e40282b4833395e9bad2b9e9feec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to ensure proper error handling when invalid or incomplete data is provided to event processing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->