### PR TITLE
Fix BraketBackend instantiation

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -356,7 +356,6 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     """
     import boto3  # type: ignore
     import redis  # type: ignore
-    from braket.aws import AwsDevice  # type: ignore
 
     evt = event if isinstance(event, HashEvent) else HashEvent.from_dict(event)
     salt_hex = evt.salt
@@ -427,8 +426,7 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
     else:
         num_bytes = 10
     device_arn = device_arn or "arn:aws:braket:::device/qpu/ionq/ionQdevice"
-    device = AwsDevice(device_arn)
-    backend = BraketBackend(device=device, device_arn=device_arn, num_bytes=num_bytes)
+    backend = BraketBackend(device=None, device_arn=device_arn, num_bytes=num_bytes)
 
     def _producer() -> bytes:
         return backend.run(seed)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -136,6 +136,11 @@ def _setup_modules(
     )
     monkeypatch.setitem(
         sys.modules,
+        "botocore.exceptions",
+        types.SimpleNamespace(NoCredentialsError=Exception),
+    )
+    monkeypatch.setitem(
+        sys.modules,
         "braket.circuits",
         types.SimpleNamespace(Circuit=lambda: FakeCircuit()),
     )


### PR DESCRIPTION
## Summary
- stop calling AwsDevice in lambda_handler
- instaniate BraketBackend lazily
- patch botocore.exceptions in lambda_handler tests

## Testing
- `python -m pre_commit run --files src/qs_kdf/core.py tests/test_lambda_handler.py` *(fails: No module named pre_commit)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e411b8988333a85822847e9f7a6a