### PR TITLE
Add quantum circuit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ## Table of Contents
 - [Background](#background)
+- [Quantum Circuit](#quantum-circuit)
 - [Quick Start](#quick-start)
 - [Infrastructure](#infrastructure)
 - [Development](#development)
@@ -17,6 +18,12 @@ This project demonstrates a minimal "quantum stretch". A tiny circuit runs on ma
 
 > **Security Notice**
 > The quantum stretch slows classical brute force attempts but offers no resistance once large fault‑tolerant quantum computers exist.
+
+## Quantum Circuit
+The library derives randomness from a short circuit applying Hadamard
+gates to eight qubits and measuring the result. Each shot yields one
+byte of entropy. See [docs/quantum-circuit.md](docs/quantum-circuit.md)
+for a step-by-step explanation.
 
 ## Quick Start
 ### Installation

--- a/docs/KDF.md
+++ b/docs/KDF.md
@@ -13,8 +13,9 @@
 | Quantum adversary  | Large-scale QPU              | Monitoring, limited benefit     |
 
 The quantum bytes are fetched from AWS Braket in production or generated locally
-during development. This makes brute-force attempts expensive because each
-password guess must reproduce the extra step.
+during development. The small circuit used to obtain them is outlined in
+[quantum-circuit.md](quantum-circuit.md). This extra step makes brute-force
+attempts expensive because each password guess must reproduce the service call.
 
 ## Flow Diagram
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,8 +145,9 @@ Follow these steps to provision the cloud resources:
 ``REDIS_CERT_REQS`` defaults to ``required``. ``optional`` allows failures
 while keeping TLS enabled. Unverified TLS is no longer supported.
 
-The random bytes are fetched from AWS Braket by running a tiny circuit. Ensure
-your credentials permit Braket execution. See the
-[Braket documentation](https://docs.aws.amazon.com/braket/)
+The random bytes are fetched from AWS Braket by running a tiny circuit. The
+process is described in detail in
+[quantum-circuit.md](quantum-circuit.md). Ensure your credentials permit
+Braket execution. See the [Braket documentation](https://docs.aws.amazon.com/braket/)
 for further details. ``BraketBackend`` uses the IonQ device by default but you
 may pass ``device_arn`` to select a different ARN.

--- a/docs/quantum-circuit.md
+++ b/docs/quantum-circuit.md
@@ -1,0 +1,35 @@
+# Quantum Circuit
+
+This document explains the tiny circuit used by `BraketBackend` to
+produce random bytes. The implementation relies on a simple pattern of
+Hadamard gates followed by measurements.
+
+## Overview
+
+1. **Initialization** – The circuit allocates eight qubits starting in
+the |0⟩ ground state.
+2. **Superposition** – A Hadamard gate `H` is applied to each qubit.
+   This transforms |0⟩ into 1/√2(|0⟩ + |1⟩), yielding a uniform
+   probability of measuring 0 or 1.
+3. **Measurement** – All qubits are measured in the computational
+   basis. Each shot returns eight classical bits.
+4. **Byte assembly** – The backend requests `num_bytes` shots. Each
+   result is converted from binary to an integer between 0 and 255 and
+   appended to a byte array.
+
+The procedure uses real hardware when available. Errors during
+initialization leave the backend in a disabled state, raising a
+`RuntimeError` on first use.
+
+## Why this works
+
+Measuring a qubit prepared with a Hadamard gate yields 0 or 1 with equal
+probability. Repeating the circuit provides a stream of unbiased random
+bits. Grouping eight bits forms a single byte. The simple structure
+avoids entanglement and keeps device execution time minimal while still
+leveraging quantum randomness.
+
+For development or offline operation, the library ships with a
+`LocalBackend` that deterministically hashes the stretched password to
+produce the same number of bytes. This makes tests reproducible without
+AWS access.


### PR DESCRIPTION
## Summary
- document the small quantum circuit used in `BraketBackend`
- link to the new file from README, KDF, and Getting Started

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e3d2c900833388fafda275deb0c8