### PR TITLE
Update lambda packaging script

### DIFF
--- a/docs/lambda-build.md
+++ b/docs/lambda-build.md
@@ -1,10 +1,11 @@
 # Packaging the Lambda Function
 
-`scripts/package_lambda.sh` bundles the source code and Python dependencies into
-`build/lambda.zip`. This archive is ready for manual upload to AWS Lambda or for
-use by deployment tooling.
+`scripts/package_lambda.sh` bundles the runtime modules and Python
+dependencies into `build/lambda.zip`. This archive is ready for manual
+upload to AWS Lambda or for use by deployment tooling.
 
 Run the script whenever you update the runtime dependencies in
 `requirements.txt` or change code under `src/`. The script installs the
-packages into `build/lambda/`, copies the project sources, and creates the zip
-file.
+packages into `build/lambda/`, copies only the `qs_kdf` package and
+`qsargon2.py`, and then creates the zip file. Tests and helper scripts are
+intentionally omitted from the archive.

--- a/scripts/package_lambda.sh
+++ b/scripts/package_lambda.sh
@@ -10,10 +10,11 @@ rm -rf "$OUT"
 mkdir -p "$OUT"
 
 # Install only runtime dependencies
-
 pip install --quiet --target "$OUT" -r "$ROOT/requirements.txt"
-# Copy source code into build dir
-cp -r "$ROOT"/src/* "$OUT"/
+
+# Copy runtime modules into build dir
+cp -r "$ROOT/src/qs_kdf" "$OUT"
+cp "$ROOT/src/qsargon2.py" "$OUT"
 
 # Package all files into lambda.zip
 cd "$OUT" && zip -r ../lambda.zip .


### PR DESCRIPTION
## Summary
- copy only runtime modules in `package_lambda.sh`
- mention limited package contents in lambda build docs

## Testing
- `pre-commit run --files docs/lambda-build.md scripts/package_lambda.sh` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e41d3c7c833384ec444dbc567529