### PR TITLE
Enforce digest length in CLI

### DIFF
--- a/src/qs_kdf/cli.py
+++ b/src/qs_kdf/cli.py
@@ -126,6 +126,10 @@ def main(argv: list[str] | None = None) -> int:
             raise argparse.ArgumentTypeError(
                 f"invalid hex value for --digest: {args.digest}"
             ) from exc
+        if len(digest) != 32:
+            raise argparse.ArgumentTypeError(
+                f"--digest must decode to 32 bytes, got {len(digest)}"
+            )
         pepper_env = os.getenv("QS_PEPPER")
         if pepper_env is None:
             parser.error("QS_PEPPER environment variable required")

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -497,6 +497,11 @@ def test_cli_invalid_digest(_pepper):
         cli_module.main(["verify", "pw", "--salt", "01" * 16, "--digest", "zz"])
 
 
+def test_cli_digest_length(_pepper):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli_module.main(["verify", "pw", "--salt", "01" * 16, "--digest", "00" * 31])
+
+
 def test_cli_pepper_length(monkeypatch):
     monkeypatch.setenv("QS_PEPPER", "short")
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- ensure `--digest` decodes to 32 bytes in CLI
- test digest length validation

## Testing
- `pre-commit run --files src/qs_kdf/cli.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e42408e08333b4f386efaf032aac