### PR TITLE
Load pepper from environment on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ for consistent benchmarking.
 
 ### QS_PEPPER
 
-Local hashing fails unless ``QS_PEPPER`` is set to a 32-byte secret. Export
-your own value before invoking the CLI. See
+The pepper is loaded at runtime using ``qs_kdf.constants.get_pepper()``. Set
+``QS_PEPPER`` to a 32-byte secret to override the shipped default. The CLI
+requires this variable for local hashing. See
 [docs/getting-started.md](docs/getting-started.md) for details.
 
 The ``BraketBackend`` defaults to the IonQ QPU but accepts a ``device_arn``

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,8 +53,9 @@ In this demo it returns a fixed value but shows how the API would be used in
 production.
 
 The repository ships with a static 32-byte pepper used for these examples.
-Set ``QS_PEPPER`` to override it when running locally and replace it with your
-own secret when deploying.
+``qs_kdf.constants.get_pepper()`` reads ``QS_PEPPER`` each time a hash is
+computed. Set this variable when running locally and replace it with your own
+secret when deploying.
 
 Passwords longer than 64 bytes or salts over 32 bytes are rejected by both
 the CLI and Lambda handler to keep memory usage predictable.

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -2,11 +2,12 @@
 
 import os
 
-
 _DEFAULT_PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for tests
 
 
-def _load_pepper() -> bytes:
+def get_pepper() -> bytes:
+    """Return pepper bytes loaded from ``QS_PEPPER``."""
+
     env = os.getenv("QS_PEPPER")
     if env is None:
         return _DEFAULT_PEPPER
@@ -15,8 +16,6 @@ def _load_pepper() -> bytes:
         raise RuntimeError("QS_PEPPER must be 32 bytes")
     return value
 
-
-PEPPER = _load_pepper()
 
 # Maximum lengths enforced by the CLI and Lambda handler
 MAX_PASSWORD_BYTES = 64


### PR DESCRIPTION
## Summary
- expose `get_pepper` function to pull QS_PEPPER at call time
- use `get_pepper` in `qstretch`, CLI and tests
- document runtime loading of pepper

## Testing
- `pre-commit run --files README.md docs/getting-started.md src/qs_kdf/cli.py src/qs_kdf/constants.py src/qs_kdf/core.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e3fbeea88333bcb18c1dfeed4723