### PR TITLE
Require QS_PEPPER for imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
 - [experimental] Quantum-Stretch KDF enabled for new logins; legacy hashes auto-upgrade on first successful auth.
+- `QS_PEPPER` environment variable is now mandatory; the library raises a
+  `RuntimeError` if it is unset.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,9 +52,9 @@ connectivity. Pass `--cloud` to route the request through the Lambda handler.
 In this demo it returns a fixed value but shows how the API would be used in
 production.
 
-The repository ships with a static 32-byte pepper used for these examples.
-Set ``QS_PEPPER`` to override it when running locally and replace it with your
-own secret when deploying.
+The command requires a 32-byte pepper provided via the ``QS_PEPPER``
+environment variable. Set this to your secret when running locally or
+deploying.
 
 Passwords longer than 64 bytes or salts over 32 bytes are rejected by both
 the CLI and Lambda handler to keep memory usage predictable.

--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -3,13 +3,20 @@
 import os
 
 
-_DEFAULT_PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for tests
-
 
 def _load_pepper() -> bytes:
+    """Return 32-byte pepper from ``QS_PEPPER``.
+
+    Raises:
+        RuntimeError: When ``QS_PEPPER`` is unset or not 32 bytes.
+
+    Returns:
+        bytes: Pepper value.
+    """
+
     env = os.getenv("QS_PEPPER")
     if env is None:
-        return _DEFAULT_PEPPER
+        raise RuntimeError("QS_PEPPER environment variable required")
     value = env.encode()
     if len(value) != 32:
         raise RuntimeError("QS_PEPPER must be 32 bytes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+os.environ.setdefault("QS_PEPPER", "x" * 32)
+

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("QS_PEPPER", "x" * 32)
+
 import base64
 import hashlib
 import ssl

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("QS_PEPPER", "x" * 32)
+
 import argparse
 import contextlib
 import importlib

--- a/tests/test_qsargon2.py
+++ b/tests/test_qsargon2.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("QS_PEPPER", "x" * 32)
+
 import qs_kdf
 
 

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("QS_PEPPER", "x" * 32)
+
 import pytest
 from qs_kdf.core import RedisCache
 

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("QS_PEPPER", "x" * 32)
+
 import importlib
 
 


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when `QS_PEPPER` is unset
- document the mandatory `QS_PEPPER` variable
- set `QS_PEPPER` in tests via `conftest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e42de60c8333ba60ced4d8f135ae