### PR TITLE
Remove pepper fallback

### DIFF
--- a/src/qs_kdf/constants.py
+++ b/src/qs_kdf/constants.py
@@ -3,13 +3,10 @@
 import os
 
 
-_DEFAULT_PEPPER = b"fixedPepper32B012345678901234567"  # 32 bytes used for tests
-
-
 def _load_pepper() -> bytes:
     env = os.getenv("QS_PEPPER")
     if env is None:
-        return _DEFAULT_PEPPER
+        raise RuntimeError("QS_PEPPER environment variable required")
     value = env.encode()
     if len(value) != 32:
         raise RuntimeError("QS_PEPPER must be 32 bytes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Ensure QS_PEPPER is always defined for module imports
+os.environ.setdefault("QS_PEPPER", "x" * 32)

--- a/tests/test_qs_kdf.py
+++ b/tests/test_qs_kdf.py
@@ -7,7 +7,6 @@ import time
 import types
 import hashlib
 from argon2.low_level import hash_secret_raw, Type
-from qs_kdf.constants import PEPPER
 
 import pytest
 
@@ -37,6 +36,8 @@ def test_hash_password_length():
 def _legacy_hash_password(
     password: str, salt: bytes, backend: qs_kdf.TestBackend
 ) -> bytes:
+    from qs_kdf.constants import PEPPER
+
     pre = hashlib.sha512(password.encode() + salt + PEPPER).digest()
     pre = hashlib.sha256(pre).digest()
     quantum = backend.run(pre)


### PR DESCRIPTION
## Summary
- require QS_PEPPER at import
- load pepper for tests via conftest
- adapt qkdf tests to import constants later

## Testing
- `pre-commit run --files src/qs_kdf/constants.py tests/conftest.py tests/test_qs_kdf.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fba193948333aad18b1cbd0b5bcd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced requirement to set the QS_PEPPER environment variable, removing any built-in default for added security.
  * Updated test setup to ensure QS_PEPPER is always defined during testing.
  * Refactored import statements in tests for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->