### PR TITLE
Fix lambda num_bytes validation

### DIFF
--- a/src/qs_kdf/core.py
+++ b/src/qs_kdf/core.py
@@ -424,9 +424,14 @@ def lambda_handler(event: Mapping[str, Any] | HashEvent, _ctx) -> dict:
         else None
     )
     if num_bytes is not None:
-        num_bytes = int(num_bytes)
+        try:
+            num_bytes = int(num_bytes)
+        except Exception as exc:
+            raise RuntimeError("num_bytes must be an integer") from exc
     else:
         num_bytes = 10
+    if num_bytes <= 0:
+        raise RuntimeError("num_bytes must be a positive integer")
     device_arn = device_arn or "arn:aws:braket:::device/qpu/ionq/ionQdevice"
     backend = BraketBackend(device=None, device_arn=device_arn, num_bytes=num_bytes)
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -255,3 +255,27 @@ def test_lambda_handler_port_out_of_range(monkeypatch, _env):
     event = asdict(HashEvent(password="pw", salt="56" * 16))
     with pytest.raises(RuntimeError, match="REDIS_PORT must be between 1 and 65535"):
         lambda_handler(event, None)
+
+
+def test_lambda_handler_invalid_num_bytes(monkeypatch, _env):
+    redis_client = FakeRedisClient()
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("10101010")
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = asdict(HashEvent(password="pw", salt="66" * 16))
+    event["num_bytes"] = "oops"
+    with pytest.raises(RuntimeError, match="num_bytes must be an integer"):
+        lambda_handler(event, None)
+
+
+def test_lambda_handler_negative_num_bytes(monkeypatch, _env):
+    redis_client = FakeRedisClient()
+    kms = FakeKMS(b"pepper", b"cipher")
+    device = FakeBraketDevice("10101010")
+    _setup_modules(monkeypatch, kms, redis_client, device)
+
+    event = asdict(HashEvent(password="pw", salt="77" * 16))
+    event["num_bytes"] = -1
+    with pytest.raises(RuntimeError, match="num_bytes must be a positive integer"):
+        lambda_handler(event, None)


### PR DESCRIPTION
## Summary
- guard lambda num_bytes parsing with `try/except`
- forbid non-positive `num_bytes`
- test negative or invalid `num_bytes`

## Testing
- `pre-commit run --files src/qs_kdf/core.py tests/test_lambda_handler.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fba794a48333bc35fb9aa12f604b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid or negative values of the input parameter related to output size, ensuring clearer error messages for incorrect inputs.

* **Tests**
  * Added new tests to verify proper error handling and validation for invalid or negative input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->