### PR TITLE
Fix CDK synth step failure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           files: ./coverage.xml
           token: ${{ env.CODECOV_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install CDK CLI
+        run: npm install -g aws-cdk
       - name: CDK Synth
         working-directory: infra
         run: cdk synth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,3 @@ jobs:
       - name: CDK Synth
         working-directory: infra
         run: cdk synth
-        continue-on-error: true

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "python3 app.py"
+}


### PR DESCRIPTION
## Summary
- fail the GitHub Actions workflow when `cdk synth` fails

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: `pre-commit` not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fbae9fc88333802e24afdf934f50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to set up Node.js 20 and install AWS CDK CLI before running CDK synth.
  * CDK synth step now fails the job if an error occurs, instead of continuing.
  * Added configuration to specify the application command for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->