### PR TITLE
Improve codex setup for offline installs

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -4,17 +4,25 @@ set -euo pipefail
 # Configure runtimes
 export CODEX_ENV_PYTHON_VERSION="3.12"
 export CODEX_ENV_NODE_VERSION="20"
-source /opt/codex/setup_universal.sh
+if [ -f /opt/codex/setup_universal.sh ]; then
+    # shellcheck disable=SC1091
+    source /opt/codex/setup_universal.sh || true
+fi
 
 uv venv venv
 source venv/bin/activate
 
-UV_ARGS="--no-index --find-links=/opt/wheels"
+UV_ARGS=""
+if [ -d /opt/wheels ]; then
+    UV_ARGS="--no-index --find-links=/opt/wheels"
+fi
 
 uv pip install ${UV_ARGS} -r requirements.txt
 uv pip install ${UV_ARGS} -r requirements-dev.txt
 uv pip install ${UV_ARGS} -r infra/requirements.txt
 uv pip install ${UV_ARGS} -e .
-uv pip install ${UV_ARGS} pre-commit
+uv pip install ${UV_ARGS} pre-commit || true
 
-pre-commit install
+if command -v pre-commit >/dev/null 2>&1; then
+    pre-commit install
+fi


### PR DESCRIPTION
## Summary
- make the setup script resilient when Node tooling is unavailable
- support running without the `/opt/wheels` cache

## Testing
- `pytest -q`
- `pre-commit run --files .codex/setup.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a060fef38833391684d732e388030